### PR TITLE
Fixes Anvil support of local build pack

### DIFF
--- a/lib/hatchet/anvil_app.rb
+++ b/lib/hatchet/anvil_app.rb
@@ -3,6 +3,13 @@ require 'stringio'
 
 module Hatchet
   class AnvilApp < App
+
+    def initialize(directory, options = {})
+      @buildpack   = options[:buildpack]
+      @buildpack ||= File.expand_path('.')
+      super
+    end
+
     def push!
       slug_url = nil
 
@@ -19,6 +26,7 @@ module Hatchet
         end
       rescue Anvil::Builder::BuildError => e
         output = $stderr.dup
+        stdout_orig.puts output.string # print the errors to the test output
         return [false, output.string]
       ensure
         $stderr = stderr_orig

--- a/test/fixtures/builpacks/null-buildpack/bin/compile
+++ b/test/fixtures/builpacks/null-buildpack/bin/compile
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# bin/compile <build-dir> <cache-dir>
+
+echo "-----> Nothing to do."

--- a/test/fixtures/builpacks/null-buildpack/bin/detect
+++ b/test/fixtures/builpacks/null-buildpack/bin/detect
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# bin/detect <build-dir>
+
+echo "Null"
+exit 0

--- a/test/fixtures/builpacks/null-buildpack/bin/release
+++ b/test/fixtures/builpacks/null-buildpack/bin/release
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "--- {}"

--- a/test/fixtures/builpacks/null-buildpack/hatchet.json
+++ b/test/fixtures/builpacks/null-buildpack/hatchet.json
@@ -1,0 +1,5 @@
+{
+  "hatchet": {"directory": "../.."},
+  "rails3": ["git@github.com:codetriage/codetriage.git"],
+  "rails2": ["git@github.com:heroku/rails2blog.git"]
+}

--- a/test/fixtures/builpacks/null-buildpack/readme.md
+++ b/test/fixtures/builpacks/null-buildpack/readme.md
@@ -1,0 +1,41 @@
+# Heroku Buildpack: Ø
+
+Use Ø if you need Heroku to execute a binary.
+
+## Usage
+
+Create a directory for our Heroku app:
+
+```bash
+$ mkdir -p myapp/bin
+$ cd myapp
+```
+
+Here is an example of an executable that will run on 64bit linux machine:
+
+```bash
+$ echo -e "#\!/usr/bin/env bash\n echo hello world" > ./bin/program
+$ echo -e "program: bin/program" > Procfile
+$ chmod +x ./bin/program
+$ ./bin/program
+hello world
+```
+
+Push the app to Heroku and run our executable:
+
+```bash
+$ git init; git add .; git commit -am 'init'
+$ heroku create --buildpack http://github.com/ryandotsmith/null-buildpack.git
+$ git push heroku master
+$ heroku run program
+Running `program` attached to terminal... up, run.8663
+hello world
+```
+
+## Motivation
+
+I wanted to run various executables (e.g. [log-shuttle](https://github.com/ryandotsmith/log-shuttle)) on Heroku without compiling them on Heroku. Thus, I compile programs on my linux 64 machine, or fetch the binary from the project, commit them to a repo and then run them on Heroku with the Ø buildpack.
+
+## Issues
+
+You will need to make sure that a 64bit linux machine can execute the binary.

--- a/test/hatchet/anvil_test.rb
+++ b/test/hatchet/anvil_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class AnvilTest < Test::Unit::TestCase
+  def test_deploy
+    Dir.chdir('test/fixtures/builpacks/null-buildpack') do
+      Hatchet::AnvilApp.new("codetriage",debug: true).deploy do |app|
+        assert true
+        app.run("bash") do |cmd|
+          # cmd.run("cd public/assets")
+
+          assert cmd.run("cat Gemfile").include?("gem 'pg'")
+
+          # deploying with null buildpack, no assets should be compiled
+          refute cmd.run("ls public/assets").include?("application.css")
+        end
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
Right now the `@buildpack` var is nil which causes Anvil to default to the production build pack, this change tells Anvil that we want to build the build pack in the current directory. 

Anvil deploys are now tested
