### PR TITLE
Avoid hitting app limits with tests

### DIFF
--- a/hatchet.gemspec
+++ b/hatchet.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "threaded",      "~> 0"
 
 
+  gem.add_development_dependency "minitest",       "~> 4.0"
   gem.add_development_dependency "rake",           "~> 10"
   gem.add_development_dependency "mocha",          "~> 1"
   gem.add_development_dependency "parallel_tests", "~> 0"

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -11,7 +11,7 @@ require 'stringio'
 
 
 module Hatchet
-  RETRIES = Integer(ENV['HATCHET_RETRIES'] || 1)
+  RETRIES   = Integer(ENV['HATCHET_RETRIES']   || 1)
 
   class App
   end
@@ -37,6 +37,7 @@ module Hatchet
 end
 
 require 'hatchet/version'
+require 'hatchet/reaper'
 require 'hatchet/app'
 require 'hatchet/anvil_app'
 require 'hatchet/git_app'

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -1,0 +1,48 @@
+module Hatchet
+  # Hatchet apps are useful after the tests run for debugging purposes
+  # the reaper is designed to allow the most recent apps to stay alive
+  # while keeping the total number of apps under the global Heroku limit.
+  # Any time you're worried about hitting the limit call @reaper.cycle
+  #
+  class Reaper
+    HEROKU_APP_LIMIT = Integer(ENV["HEROKU_APP_LIMIT"]  || 100) # the number of apps heroku allows you to keep
+    HATCHET_APP_LIMT = Integer(ENV["HATCHET_APP_LIMIT"] || 20)  # the number of apps hatchet keeps around
+    DEFAULT_REGEX = /^hatchet-t-/
+    attr_accessor :apps
+
+
+    def initialize(heroku, regex = DEFAULT_REGEX)
+      @heroku = heroku
+      @regex  = regex
+    end
+
+    # Ascending order, oldest is last
+    def get_apps
+      @apps         = @heroku.get_apps.body.sort_by {|app| DateTime.parse(app["created_at"]) }.reverse
+      @hatchet_apps = @apps.select {|app| app["name"].match(@regex) }
+      @apps
+    end
+
+    def cycle(apps = get_apps)
+      if over_limit?
+        destroy_oldest
+        cycle
+      else
+        # do nothing
+      end
+    end
+
+    def destroy_oldest
+      oldest_name  = @hatchet_apps.pop["name"]
+      puts "Destroying #{oldest_name.inspect}. Hatchet app limit: #{HATCHET_APP_LIMT}"
+      @heroku.delete_app(oldest_name)
+    end
+
+    private
+
+    def over_limit?
+      @apps.count > HEROKU_APP_LIMIT || @hatchet_apps.count > HATCHET_APP_LIMT
+    end
+  end
+end
+


### PR DESCRIPTION
The Reaper is designed to keep you under your Heroku app limit and allow you to keep recently deployed hatchet apps alive for continued debugging.
