### PR TITLE
allow the app to set the stack on create

### DIFF
--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -1,6 +1,6 @@
 module Hatchet
   class App
-    attr_reader :name, :directory, :repo_name
+    attr_reader :name, :stack, :directory, :repo_name
 
     class FailedDeploy < StandardError
       def initialize(app, output)
@@ -16,6 +16,7 @@ module Hatchet
       @repo_name     = repo_name
       @directory     = config.path_for_name(@repo_name)
       @name          = options[:name]          || "hatchet-t-#{SecureRandom.hex(10)}"
+      @stack         = options[:stack]
       @debug         = options[:debug]         || options[:debugging]
       @allow_failure = options[:allow_failure] || false
       @labs          = ([] << options[:labs]).flatten.compact
@@ -99,7 +100,7 @@ module Hatchet
     def create_app
       3.times.retry do
         begin
-          heroku.post_app(name: name)
+          heroku.post_app({ name: name, stack: stack }.delete_if {|k,v| v.nil? })
         rescue Heroku::API::Errors::RequestFailed => e
           @reaper.cycle if e.message.match(/app limit/)
           raise e

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class AppTest < Test::Unit::TestCase
+  def test_create_app_with_stack
+    app = Hatchet::App.new("rails3_mri_193", stack: "cedar")
+    app.create_app
+    assert_equal 'cedar', app.heroku.get_app(app.name).body["stack"]
+  end
+end


### PR DESCRIPTION
Now that there's more than one cedar stack on Heroku. It'd be nice to be able to specify the stack on app create vs after the app is created. This will reduce the calls by one and not force us to do an empty git push and switch.