### PR TITLE
Upgrade platform-api to version 2

### DIFF
--- a/hatchet.gemspec
+++ b/hatchet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "platform-api",  "~> 1"
+  gem.add_dependency "platform-api",  "~> 2"
   gem.add_dependency "heroku-api",    "~> 0"
   gem.add_dependency "activesupport", "~> 4"
   gem.add_dependency "rrrretry",      "~> 1"
@@ -36,4 +36,3 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "parallel_tests", "~> 0"
   gem.add_development_dependency "travis",         "~> 1"
 end
-


### PR DESCRIPTION
This fixed some [failures on the Scala buildpack](https://travis-ci.org/heroku/heroku-buildpack-scala/jobs/243066806) that I believe may be related to the [V2 Brownouts](https://status.heroku.com/incidents/1188).

Note that CI is failing due to the CLI v6 update. But even running the tests locally, I get failures that appear to be related to heroku-16 and ruby 1.9.3.