### PR TITLE
Add API rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## HEAD
 
+## 4.0.0
+
+- Introduce API rate limiting (#46)
+- Deprecate App#platform_api method (#46)
+
 ## 3.1.1
 
 - Better errors when no lockfile is found #43

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -17,6 +17,7 @@ require 'hatchet/app'
 require 'hatchet/anvil_app'
 require 'hatchet/git_app'
 require 'hatchet/config'
+require 'hatchet/api_rate_limit'
 
 module Hatchet
   RETRIES = Integer(ENV['HATCHET_RETRIES']   || 1)

--- a/lib/hatchet/api_rate_limit.rb
+++ b/lib/hatchet/api_rate_limit.rb
@@ -1,0 +1,40 @@
+# Wraps platform-api and adds API rate limits
+#
+# Instead of:
+#
+#     platform_api.pipeline.create(name: @name)
+#
+# Use:
+#
+#     api_rate_limit = ApiRateLimit.new(platform_api)
+#     api_rate_limit.call.pipeline.create(name: @name)
+#
+class ApiRateLimit
+  def initialize(platform_api)
+    @platform_api = platform_api
+    @capacity = 1
+    @called   = 0
+  end
+
+
+  # Sleeps for progressively longer when api rate limit capacity
+  # is lower.
+  #
+  # Unfortunatley `@platform_api.rate_limit` is an extra API
+  # call, so by checking our limit, we also are using our limit 😬
+  # to partially mitigate this, only check capacity every 5
+  # api calls, or if the
+  def call
+    @called += 1
+
+    if @called > 5 || @capacity < 1000
+      @called = 0
+      @capacity = @platform_api.rate_limit.info["remaining"]
+    end
+
+    sleep_time = (60/@capacity) if @capacity > 0.1 # no divide by zero
+    sleep(sleep_time || 60)
+
+    return @platform_api
+  end
+end

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -11,14 +11,14 @@ module Hatchet
     attr_accessor :apps
 
 
-    def initialize(platform_api:, regex: DEFAULT_REGEX)
-      @platform_api = platform_api
+    def initialize(api_rate_limit: , regex: DEFAULT_REGEX)
+      @api_rate_limit = api_rate_limit
       @regex        = regex
     end
 
     # Ascending order, oldest is last
     def get_apps
-      apps          = @platform_api.app.list.sort_by { |app| DateTime.parse(app["created_at"]) }.reverse
+      apps          = @api_rate_limit.call.app.list.sort_by { |app| DateTime.parse(app["created_at"]) }.reverse
       @app_count    = apps.count
       @hatchet_apps = apps.select {|app| app["name"].match(@regex) }
     end
@@ -63,7 +63,7 @@ module Hatchet
     def destroy_by_id(name:, id:, details: "")
       @message = "Destroying #{name.inspect}: #{id}. #{details}"
       puts @message
-      @platform_api.app.delete(id)
+      @api_rate_limit.call.app.delete(id)
     end
 
     private

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "3.1.1"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
When deploying lots of apps for a buildpack it’s very easy to hit the Heroku API rate limit. When this happens builds start to fail with 422 status. It’s pretty cryptic. Usually what happened is there are multiple CI services running at once and they flooded the API.

This patch adds a tiny sleep before each API call. The sleep is proportional to the amount of capacity left in your rate limit bucket. If you have lots of requests left then the sleep is barely noticeable. If you have only 1 left, then you’ll be sleeping for a full 60 seconds.