### PR TITLE
Re-use ApiRateLimit in CI API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 4.0.1
+
+- Rate limit Heroku CI
+
 ## 4.0.0
 
 - Introduce API rate limiting (#46)

--- a/lib/hatchet/api_rate_limit.rb
+++ b/lib/hatchet/api_rate_limit.rb
@@ -23,7 +23,7 @@ class ApiRateLimit
   # Unfortunatley `@platform_api.rate_limit` is an extra API
   # call, so by checking our limit, we also are using our limit 😬
   # to partially mitigate this, only check capacity every 5
-  # api calls, or if the
+  # api calls, or if the current capacity is under 1000
   def call
     @called += 1
 

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -236,11 +236,14 @@ module Hatchet
 
       # create_app
       # platform_api.pipeline_coupling.create(app: name, pipeline: @pipeline_id, stage: "development")
-      test_run = TestRun.new(token:      api_key,
-                             buildpacks: @buildpacks,
-                             timeout:    timeout,
-                             app:        self,
-                             pipeline:   @pipeline_id)
+      test_run = TestRun.new(
+        token:          api_key,
+        buildpacks:     @buildpacks,
+        timeout:        timeout,
+        app:            self,
+        pipeline:       @pipeline_id,
+        api_rate_limit: api_rate_limit
+     )
 
       Hatchet::RETRIES.times.retry do
         test_run.create_test_run

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end


### PR DESCRIPTION
This is not ideal since the call to `@platform_api.rate_limit.info["remaining”]` takes away from our rate limit, however it doesn’t look like all the API endpoints for CI are currently emitting a `"Ratelimit-Remaining”` header.