### PR TITLE
Provide safe ability to modify files on disk

### DIFF
--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -10,6 +10,7 @@ module Hatchet
     BUILDPACK_URL = "https://github.com/heroku/heroku-buildpack-ruby.git"
 
     attr_reader :name, :stack, :directory, :repo_name
+    attr_accessor :before_deploy
 
     class FailedDeploy < StandardError
       def initialize(app, output)
@@ -21,16 +22,28 @@ module Hatchet
       end
     end
 
-    def initialize(repo_name, options = {})
+    def initialize(repo_name,
+                   stack: "",
+                   name: default_name,
+                   debug: nil,
+                   debugging: nil,
+                   allow_failure: false,
+                   labs: [],
+                   buildpack: nil,
+                   buildpacks: nil,
+                   buildpack_url: nil,
+                   before_deploy: nil
+                  )
       @repo_name     = repo_name
       @directory     = config.path_for_name(@repo_name)
-      @name          = options[:name]          || "hatchet-t-#{SecureRandom.hex(10)}"
-      @stack         = options[:stack]
-      @debug         = options[:debug]         || options[:debugging]
-      @allow_failure = options[:allow_failure] || false
-      @labs          = ([] << options[:labs]).flatten.compact
-      @buildpacks    = options[:buildpack] || options[:buildpacks] || options[:buildpack_url] || self.class.default_buildpack
+      @name          = name
+      @stack         = stack
+      @debug         = debug || debugging
+      @allow_failure = allow_failure
+      @labs          = ([] << labs).flatten.compact
+      @buildpacks    = buildpack || buildpacks || buildpack_url || self.class.default_buildpack
       @buildpacks    = Array(@buildpacks)
+      @before_deploy = before_deploy
       @reaper        = Reaper.new(api_rate_limit: api_rate_limit)
     end
 
@@ -148,13 +161,18 @@ module Hatchet
       puts "Hatchet setup: #{name.inspect} for #{repo_name.inspect}"
       create_app
       set_labs!
-      # heroku.put_config_vars(name, 'BUILDPACK_URL' => @buildpack)
-      buildpack_list = @buildpacks.map {|pack| { buildpack: pack }}
+      buildpack_list = @buildpacks.map { |pack| { buildpack: pack } }
       api_rate_limit.call.buildpack_installation.update(name, updates: buildpack_list)
+
+      call_before_deploy
       @app_is_setup = true
       self
     end
     alias :setup :setup!
+
+    def commit!
+      local_cmd_exec!('git add .; git commit -m next')
+    end
 
     def push_without_retry!
       raise NotImplementedError
@@ -191,7 +209,6 @@ module Hatchet
     ensure
       self.teardown!
     end
-
 
     def push
       max_retries = @allow_failure ? 1 : RETRIES
@@ -290,9 +307,38 @@ module Hatchet
       @api_rate_limit ||= ApiRateLimit.new(@platform_api)
     end
 
-    private
-    # if someone uses bundle exec
-    def bundle_exec
+    private def needs_commit?
+      out = local_cmd_exec!('git status --porcelain').chomp
+
+      return false if out.empty?
+      true
+    end
+
+    private def local_cmd_exec!(cmd)
+      out = `#{cmd}`
+      raise "Command: #{cmd} failed: #{out}" unless $?.success?
+      out
+    end
+
+    private def default_name
+      "hatchet-t-#{SecureRandom.hex(10)}"
+    end
+
+    private def call_before_deploy
+      return unless before_deploy
+      raise "before_deploy: #{before_deploy.inspect} must respond to :call"  unless before_deploy.respond_to?(:call)
+      raise "before_deploy: #{before_deploy.inspect} must respond to :arity" unless before_deploy.respond_to?(:arity)
+
+      if before_deploy.arity == 1
+        before_deploy.call(self)
+      else
+        before_deploy.call
+      end
+
+      commit! if needs_commit?
+    end
+
+    private def bundle_exec
       if defined?(Bundler)
         Bundler.with_clean_env do
           yield

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -7,4 +7,41 @@ class AppTest < Minitest::Test
     app.create_app
     assert_equal stack, app.platform_api.app.info(app.name)["build_stack"]["name"]
   end
+
+  def test_before_deploy
+    @called = false
+    @dir    = false
+    before_deploy = Proc.new do
+      @called = true
+      @dir    = Dir.pwd
+    end
+
+    app = Hatchet::App.new("default_ruby", before_deploy: before_deploy)
+    def app.push_with_retry!; end # Don't actually deploy
+
+    app.deploy do
+      assert_equal true,    @called
+
+      assert_equal Dir.pwd, @dir
+    end
+
+    refute_equal Dir.pwd, @dir
+  end
+
+  def test_auto_commits_code
+    string = "foo#{SecureRandom.hex}"
+    before_deploy = Proc.new do |app|
+      assert_equal false, app.send(:needs_commit?)
+      `echo "#{string}" > Gemfile`
+      assert_equal true, app.send(:needs_commit?)
+    end
+
+    app = Hatchet::App.new("default_ruby", before_deploy: before_deploy)
+    def app.push_with_retry!; end # Don't actually deploy
+
+    app.deploy do
+      assert_equal string, File.read("Gemfile").chomp
+      assert_equal false, app.send(:needs_commit?)
+    end
+  end
 end


### PR DESCRIPTION
It’s common that someone might want have a “blank” template that then gets modified for each test.

For example you could use this to add a file to the app:

```ruby
app = Hatchet::Runner.new("default_ruby”, before_deploy: -> { `echo "gem ‘rake’" >> Gemfile && bundle install` }
```

If this block changes the git directory the contents will automatically be saved as a new git commit.