### PR TITLE
Allow config to be set at initialization

### DIFF
--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -31,10 +31,11 @@ module Hatchet
                    buildpack: nil,
                    buildpacks: nil,
                    buildpack_url: nil,
-                   before_deploy: nil
+                   before_deploy: nil,
+                   config: {}
                   )
       @repo_name     = repo_name
-      @directory     = config.path_for_name(@repo_name)
+      @directory     = self.config.path_for_name(@repo_name)
       @name          = name
       @stack         = stack
       @debug         = debug || debugging
@@ -43,6 +44,7 @@ module Hatchet
       @buildpacks    = buildpack || buildpacks || buildpack_url || self.class.default_buildpack
       @buildpacks    = Array(@buildpacks)
       @before_deploy = before_deploy
+      @app_config    = config
       @reaper        = Reaper.new(api_rate_limit: api_rate_limit)
     end
 
@@ -162,6 +164,7 @@ module Hatchet
       set_labs!
       buildpack_list = @buildpacks.map { |pack| { buildpack: pack } }
       api_rate_limit.call.buildpack_installation.update(name, updates: buildpack_list)
+      set_config @app_config
 
       call_before_deploy
       @app_is_setup = true

--- a/test/hatchet/heroku_api_test.rb
+++ b/test/hatchet/heroku_api_test.rb
@@ -17,4 +17,14 @@ class HerokuApiTest < Minitest::Test
   ensure
     runner.teardown! if runner
   end
+
+
+  def test_config_vars_in_init
+    runner    = Hatchet::Runner.new("no_lockfile", config: { foo: "bar"}).setup!
+    actual    = runner.get_config
+    expected  = {"foo" => "bar"}
+    assert_equal expected, actual
+  ensure
+    runner.teardown! if runner
+  end
 end


### PR DESCRIPTION
Previously you had to 

```ruby
app = Hatchet::Runner.new(“default”)
app.set_config({
  “FOO” => "http://localhost:3000",
  “BAR” => "10000"
})
```

Now you can:

```ruby
app = Hatchet::Runner.new(“default”, config: {
  “FOO” => "http://localhost:3000",
  “BAR” => "10000"
})
```