### PR TITLE
Move setup script into it's own command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
 - 2.3.1
-before_script: 
-  - bundle exec rake hatchet:setup_travis
-  - sudo bash etc/ci_setup.sh
+before_script:
+  - bundle exec hatchet ci:setup
 script: bundle exec parallel_test test/hatchet -n 9
 after_script: bundle exec rake hatchet:teardown_travis
 env:

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -17,6 +17,24 @@ require 'date'
 require 'yaml'
 
 class HatchetCLI < Thor
+  desc "ci:install_heroku", "installs the `heroku` cli"
+  define_method("ci:install_heroku") do
+    if `which heroku` && $?.success?
+      puts "The `heroku` command is already installed"
+      return
+    else
+      puts "installing `heroku` command"
+    end
+    script = File.expand_path File.join(__dir__, "../etc/setup_heroku.sh")
+    cmd(script)
+  end
+
+  desc "ci:setup", "sets up project to run on a linux CI environment"
+  define_method("ci:setup") do
+    script = File.expand_path File.join(__dir__, "../etc/ci_setup.rb")
+    cmd(script)
+  end
+
   desc "install", "installs repos defined in 'hatchet.json'"
   def install
     warn_dot_ignore!
@@ -44,12 +62,6 @@ class HatchetCLI < Thor
     end.map(&:join)
 
     self.lock if missing_commit
-  end
-
-  def load_lockfile
-    return YAML.safe_load(File.read('hatchet.lock')).to_h
-  rescue Errno::ENOENT => e
-    raise "No such file found `hatchet.lock` please run `$ bundle exec hatchet lock`"
   end
 
   desc "locks to specific git commits", "updates hatchet.lock"
@@ -98,6 +110,11 @@ class HatchetCLI < Thor
   end
 
   private
+  def load_lockfile
+    return YAML.safe_load(File.read('hatchet.lock')).to_h
+  rescue Errno::ENOENT => e
+    raise "No such file found `hatchet.lock` please run `$ bundle exec hatchet lock`"
+  end
 
   def bad_repo?(url)
     `git ls-remote --exit-code -h "#{url}"`

--- a/etc/ci_setup.rb
+++ b/etc/ci_setup.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require 'bundler'
+puts "== Setting Up CI =="
+
+netrc_file = "#{ENV['HOME']}/.netrc"
+unless File.exists?(netrc_file)
+  File.open(netrc_file, 'w') do |file|
+    file.write <<-EOF
+machine git.heroku.com
+login #{ENV.fetch('HEROKU_API_USER')}
+password #{ENV.fetch('HEROKU_API_KEY')}
+EOF
+  end
+end
+
+[
+ "bundle exec hatchet ci:install_heroku",
+ "bundle exec hatchet install",
+ "if [ `git config --get user.email` ]; then echo 'already set'; else `git config --global user.email '#{ENV.fetch('HEROKU_API_USER')}'`; fi",
+ "if [ `git config --get user.name` ];  then echo 'already set'; else `git config --global user.name  'BuildpackTester'`      ; fi",
+].each do |command|
+  puts "== Running: #{command}"
+  Bundler.with_clean_env do
+    result = `#{command}`
+    raise "Command failed: #{command.inspect}\nResult: #{result}" unless $?.success?
+  end
+end
+puts "== Done =="

--- a/etc/setup_heroku.sh
+++ b/etc/setup_heroku.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
 sudo apt-get -qq update
 sudo apt-get install software-properties-common
 curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh

--- a/lib/hatchet/tasks.rb
+++ b/lib/hatchet/tasks.rb
@@ -1,28 +1,8 @@
 namespace :hatchet do
   task :setup_ci do
-    puts "== Setting Up Travis =="
-    netrc_file = "#{ENV['HOME']}/.netrc"
-    unless File.exists?(netrc_file)
-      File.open(netrc_file, 'w') do |file|
-        file.write <<-EOF
-machine git.heroku.com
-  login #{ENV.fetch('HEROKU_API_USER')}
-  password #{ENV.fetch('HEROKU_API_KEY')}
-EOF
-      end
-    end
-    [
-     "bundle exec hatchet install",
-     "if [ `git config --get user.email` ]; then echo 'already set'; else `git config --global user.email '#{ENV.fetch('HEROKU_API_USER')}'`; fi",
-     "if [ `git config --get user.name` ];  then echo 'already set'; else `git config --global user.name  'BuildpackTester'`      ; fi",
-    ].each do |command|
-      puts "== Running: #{command}"
-      Bundler.with_clean_env do
-        result = `#{command}`
-        raise "Command failed: #{command.inspect}\nResult: #{result}" unless $?.success?
-      end
-    end
-    puts "== Done =="
+    script = File.expand_path = File.join(__dir__, "../../etc/ci_setup.rb")
+    out = `#{script}`
+    raise "Command #{script.inspect} failed\n#{out}"
   end
 
   task :setup_travis do


### PR DESCRIPTION
When the setup script is provided as a rake task it assumes rake is installed and there is a Rakefile present. Since we already have a CLI we can instead expose that script as a CLI command instead.