### PR TITLE
app.run fixes

### DIFF
--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -113,7 +113,7 @@ module Hatchet
         arg << "=#{v.to_s.shellescape}" unless v.nil?
         arg
       end.join(" ")
-      heroku_command = "heroku run #{command.to_s.shellescape} -a #{name} #{ heroku_options }"
+      heroku_command = "heroku run -a #{name} #{heroku_options} -- #{command}"
       bundle_exec do
         if block_given?
           ReplRunner.new(cmd_type, heroku_command, options).run(&block)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -108,7 +108,11 @@ module Hatchet
     # but programatically and with more control
     def run(cmd_type, command = nil, options = {}, &block)
       command        = cmd_type.to_s if command.nil?
-      heroku_options = (options.delete(:heroku) || {}).map {|k,v| "--#{k.to_s.shellescape}=#{v.to_s.shellescape}"}.join(" ")
+      heroku_options = (options.delete(:heroku) || {}).map do |k,v|
+        arg = "--#{k.to_s.shellescape}"
+        arg << "=#{v.to_s.shellescape}" unless v.nil?
+        arg
+      end.join(" ")
       heroku_command = "heroku run #{command.to_s.shellescape} -a #{name} #{ heroku_options }"
       bundle_exec do
         if block_given?

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -113,7 +113,7 @@ module Hatchet
         arg << "=#{v.to_s.shellescape}" unless v.nil?
         arg
       end.join(" ")
-      heroku_command = "heroku run -a #{name} #{heroku_options} -- #{command}"
+      heroku_command = "heroku run -a #{name} #{heroku_options} --exit-code -- #{command}"
       bundle_exec do
         if block_given?
           ReplRunner.new(cmd_type, heroku_command, options).run(&block)

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -62,4 +62,11 @@ class AppTest < Minitest::Test
       end
     end
   end
+  
+  def test_run
+    app = Hatchet::GitApp.new("default_ruby")
+    app.deploy do
+      assert_match /ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/, app.run("ls -a Gemfile 'foo bar #baz'")
+    end
+  end
 end

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -67,6 +67,7 @@ class AppTest < Minitest::Test
     app = Hatchet::GitApp.new("default_ruby")
     app.deploy do
       assert_match /ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/, app.run("ls -a Gemfile 'foo bar #baz'")
+      assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
     end
   end
 end


### PR DESCRIPTION
- Allows options without values (say `--no-notify`) by passing `nil` as the value
- Correctly order and separate our options from the actual command using `--`
- Always report back the invoked programs's exit status, so it can be checked using `$?.exitstatus`

I wonder if we should *not* `.to_s.shellescape` the `command` part now. It leads to the whole thing being one quoted string, which the CLI then unpacks again: https://github.com/heroku/cli/blob/master/packages/run-v5/lib/helpers.js#L6-L10

All that potentially leads to is quoting madness in special cases; changing it as well *should* not impact any existing calls