### PR TITLE
4.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix `hatchet destroy` not passing rate limited API to Reaper
 - Fix undeclared variable in `App#create_app` rescue block
 - Fix race condition in `Reaper#cycle` triggering 403s in API, causing test failures
+- Allow configurable app name prefix (default "hatchet-t-") via `HATCHET_APP_PREFIX` env var
 
 ## 4.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.8
 
 - Fix `hatchet destroy` calling class from wrong module
+- Fix `hatchet destroy` not passing rate limited API to Reaper
 
 ## 4.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 4.0.8
+
+- Fix `hatchet destroy` calling class from wrong module
+
 ## 4.0.7
 
 - Exit code is now returned from `app.run` commands (https://github.com/heroku/hatchet/pull/58)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `hatchet destroy` calling class from wrong module
 - Fix `hatchet destroy` not passing rate limited API to Reaper
 - Fix undeclared variable in `App#create_app` rescue block
+- Fix race condition in `Reaper#cycle` triggering 403s in API, causing test failures
 
 ## 4.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `hatchet destroy` calling class from wrong module
 - Fix `hatchet destroy` not passing rate limited API to Reaper
+- Fix undeclared variable in `App#create_app` rescue block
 
 ## 4.0.7
 

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -98,7 +98,7 @@ class HatchetCLI < Thor
   def destroy(name=nil)
     api_key      = ENV['HEROKU_API_KEY'] || bundle_exec {`heroku auth:token`.chomp }
     platform_api = PlatformAPI.connect_oauth(api_key, cache: Moneta.new(:Null))
-    reaper       = Reaper.new(platform_api: platform_api)
+    reaper       = Hatchet::Reaper.new(platform_api: platform_api)
 
     if options[:all]
       reaper.destroy_all

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -98,7 +98,8 @@ class HatchetCLI < Thor
   def destroy(name=nil)
     api_key      = ENV['HEROKU_API_KEY'] || bundle_exec {`heroku auth:token`.chomp }
     platform_api = PlatformAPI.connect_oauth(api_key, cache: Moneta.new(:Null))
-    reaper       = Hatchet::Reaper.new(platform_api: platform_api)
+    api_rate_limit = ApiRateLimit.new(platform_api)
+    reaper       = Hatchet::Reaper.new(api_rate_limit: api_rate_limit)
 
     if options[:all]
       reaper.destroy_all

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -9,6 +9,7 @@ require 'stringio'
 require 'date'
 
 module Hatchet
+    APP_PREFIX = (ENV['HATCHET_APP_PREFIX'] || "hatchet-t-")
 end
 
 require 'hatchet/version'

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -148,7 +148,7 @@ module Hatchet
           hash = { name: name, stack: stack }
           hash.delete_if { |k,v| v.nil? }
           api_rate_limit.call.app.create(hash)
-        rescue
+        rescue => e
           @reaper.cycle
           raise e
         end

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -347,7 +347,7 @@ module Hatchet
     end
 
     private def default_name
-      "hatchet-t-#{SecureRandom.hex(10)}"
+      "#{Hatchet::APP_PREFIX}#{SecureRandom.hex(5)}"
     end
 
     private def call_before_deploy

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -9,9 +9,8 @@ module Hatchet
   class Reaper
     HEROKU_APP_LIMIT = Integer(ENV["HEROKU_APP_LIMIT"]  || 100) # the number of apps heroku allows you to keep
     HATCHET_APP_LIMT = Integer(ENV["HATCHET_APP_LIMIT"] || 20)  # the number of apps hatchet keeps around
-    DEFAULT_REGEX = /^hatchet-t-/
+    DEFAULT_REGEX = /^#{Regexp.escape(Hatchet::APP_PREFIX)}[a-f0-9]+/
     attr_accessor :apps
-
 
     def initialize(api_rate_limit: , regex: DEFAULT_REGEX)
       @api_rate_limit = api_rate_limit

--- a/lib/hatchet/test_run.rb
+++ b/lib/hatchet/test_run.rb
@@ -30,7 +30,7 @@ module Hatchet
       commit_message: "commit",
       organization:    nil
     )
-      @pipeline        = pipeline || "hatchet-t-#{SecureRandom.hex(10)}"
+      @pipeline        = pipeline || "#{Hatchet::APP_PREFIX}#{SecureRandom.hex(5)}"
       @timeout         = timeout
       @pause           = pause
       @organization    = organization

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "4.0.7"
+  VERSION = "4.0.8"
 end


### PR DESCRIPTION
- `hatchet destroy` was broken due to two issues
- `App#create_app` rescue block used undefined variable
- `Reaper#cycle` was subject to a race condition (when running tests in parallel) causing 403 API responses and thus test failures; see f111371 for a detailed explanation
- `HATCHET_APP_PREFIX` can now be used to isolate apps between e.g. Travis jobs; can be set to e.g. `HATCHET_APP_PREFIX="htcht-${TRAVIS_JOB_ID}-"` in `.travis.yml` together with `after_script: bundle exec hatchet destroy --all` for cleanup