### PR TITLE
4.0.9: make default options overridable in App#run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 4.0.9
+
+- Allow overriding of all App#run options, including option removal (by passing `Hatchet::App::SkipDefaultOption` as the value)
+
 ## 4.0.8
 
 - Fix `hatchet destroy` calling class from wrong module

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "4.0.8"
+  VERSION = "4.0.9"
 end

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -68,6 +68,16 @@ class AppTest < Minitest::Test
     app.deploy do
       assert_match /ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/, app.run("ls -a Gemfile 'foo bar #baz'")
       assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
+      sleep(3)
+      app.run("ls erpderp", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption } } )
+      assert (0 == $?.exitstatus) # $? is from the app.run use of backticks, but we asked the CLI not to return the program exit status by skipping the default "exit-code" option
+      sleep(3)
+      app.run("ls erpderp", nil, { :heroku => { "no-tty" => nil } } )
+      assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
+      sleep(3)
+      assert_match /ohai world/, app.run('echo \$HELLO \$NAME', nil, { :heroku => { "env" => "HELLO=ohai;NAME=world" } } )
+      sleep(3)
+      refute_match /ohai world/, app.run('echo \$HELLO \$NAME', nil, { :heroku => { "env" => "" } } )
     end
   end
 end


### PR DESCRIPTION
this is to e.g. allow preventing the use of --exit-code, which does not work with procfile entry names