### PR TITLE
Make tests faster by splitting out CI tests into multiple files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 2.3.1
 before_script:
   - bundle exec hatchet ci:setup
-script: bundle exec parallel_test test/hatchet -n 9
+script: bundle exec parallel_test test/hatchet -n 11
 after_script: bundle exec rake hatchet:teardown_travis
 env:
   global:

--- a/hatchet.gemspec
+++ b/hatchet.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest",       "~> 5.1"
   gem.add_development_dependency "rake",           "~> 10"
   gem.add_development_dependency "mocha",          "~> 1"
-  gem.add_development_dependency "parallel_tests", "~> 0"
+  gem.add_development_dependency "parallel_tests", "~> 2"
   gem.add_development_dependency "travis",         "~> 1"
 end

--- a/test/hatchet/ci_test.rb
+++ b/test/hatchet/ci_test.rb
@@ -1,23 +1,11 @@
 require 'test_helper'
 
 class CITest < Minitest::Test
-
-  def test_ci_create_app_with_stack
-    Hatchet::GitApp.new("rails5_ruby_schema_format").run_ci do |test_run|
-      assert_match "Ruby buildpack tests completed successfully", test_run.output
-      assert_equal :succeeded, test_run.status
-    end
-  end
-
   def test_error_with_bad_app
     error = assert_raise(Hatchet::FailedTestError) do
       Hatchet::GitApp.new("rails5_ci_fails_no_database").run_ci {}
     end
 
-    assert_match "PG::ConnectionBad: could not connect to server" ,error.message
-
-    Hatchet::GitApp.new("rails5_ci_fails_no_database", allow_failure: true).run_ci do |test_run|
-      assert_equal :errored, test_run.status
-    end
+    assert_match "PG::ConnectionBad: could not connect to server", error.message
   end
 end

--- a/test/hatchet/ci_three_test.rb
+++ b/test/hatchet/ci_three_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class CIThreeTest < Minitest::Test
+  def test_error_with_bad_app
+    Hatchet::GitApp.new("rails5_ci_fails_no_database", allow_failure: true).run_ci do |test_run|
+      assert_equal :errored, test_run.status
+    end
+  end
+end

--- a/test/hatchet/ci_too_test.rb
+++ b/test/hatchet/ci_too_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+# Split out to be faster
+class CITestToo < Minitest::Test
+  def test_ci_create_app_with_stack
+    Hatchet::GitApp.new("rails5_ruby_schema_format").run_ci do |test_run|
+      assert_match "Ruby buildpack tests completed successfully", test_run.output
+      assert_equal :succeeded, test_run.status
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,3 +23,5 @@ end
 
 
 ENV['HATCHET_BUILDPACK_BRANCH'] = "master"
+
+require 'parallel_tests/test/runtime_logger' if ENV['RECORD_RUNTIME']

--- a/tmp/parallel_runtime_test.log
+++ b/tmp/parallel_runtime_test.log
@@ -1,0 +1,3 @@
+test/hatchet/edit_repo_test.rb:5.40
+test/hatchet/local_repo_test.rb:9.60
+test/hatchet/heroku_api_test.rb:21.88


### PR DESCRIPTION
CI test is the slowest test, therefore the whole suite is dependent on the amount of time it takes to run.

Previously we were doing 3 CI test deployments in one file, we can make the suite much faster by instead splitting them into 3 different files.

I think we could further speed things up by maybe turning off the retry behavior of the CI test that we know will fail?