### PR TITLE
Safer tests by not mutating current process

### DIFF
--- a/test/hatchet/local_repo_test.rb
+++ b/test/hatchet/local_repo_test.rb
@@ -1,6 +1,18 @@
 require 'test_helper'
 
-class AppTest < Minitest::Test
+class LocalRepoTest < Minitest::Test
+  def test_in_directory_fork
+    env_name = SecureRandom.hex
+    ENV[env_name] = env_name
+
+    Hatchet::App.new("default_ruby").in_directory_fork do
+      ENV.delete(env_name)
+      assert_nil ENV[env_name]
+    end
+
+    assert_equal env_name, ENV[env_name]
+  end
+
   def test_repos_checked_into_git
     app = Hatchet::App.new("test/different-folder-for-checked-in-repos/default_ruby")
     app.in_directory do


### PR DESCRIPTION
Sometimes in a test you don't know of a bit of code will modify global state such as environment variables. To be extra safe we can run these actions inside of a fork.

Here's an example of some tests that were accidentally mutating the current env https://github.com/heroku/heroku-buildpack-ruby/pull/918.

