### PR TITLE
Heroku CI fixes

### DIFF
--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -298,8 +298,16 @@ module Hatchet
         @pipeline_id = result["id"]
       end
 
-      # create_app
-      # platform_api.pipeline_coupling.create(app: name, pipeline: @pipeline_id, stage: "development")
+      # when the CI run finishes, the associated ephemeral app created for the test run internally gets removed almost immediately
+      # the system then sees a pipeline with no apps, and deletes it, also almost immediately
+      # that would, with bad timing, mean our test run info poll in wait! would 403, and/or the delete_pipeline at the end
+      # that's why we create an app explictly (or maybe it already exists), and then associate it with with the pipeline
+      # the app will be auto cleaned up later
+      self.setup!
+      Hatchet::RETRIES.times.retry do
+        couple_pipeline(@name, @pipeline_id)
+      end
+
       test_run = TestRun.new(
         token:          api_key,
         buildpacks:     @buildpacks,
@@ -323,6 +331,10 @@ module Hatchet
 
     def create_pipeline
       api_rate_limit.call.pipeline.create(name: @name)
+    end
+
+    def couple_pipeline(app_name, pipeline_id)
+      api_rate_limit.call.pipeline_coupling.create(app: app_name, pipeline: pipeline_id, stage: "development")
     end
 
     def source_get_url

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -323,6 +323,7 @@ module Hatchet
       test_run.wait!(&block)
     ensure
       delete_pipeline(@pipeline_id) if @pipeline_id
+      @pipeline_id = nil
     end
 
     def pipeline_id

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -9,7 +9,7 @@ module Hatchet
     HATCHET_BUILDPACK_BRANCH = -> { ENV['HATCHET_BUILDPACK_BRANCH'] || ENV['HEROKU_TEST_RUN_BRANCH'] || Hatchet.git_branch }
     BUILDPACK_URL = "https://github.com/heroku/heroku-buildpack-ruby.git"
 
-    attr_reader :name, :stack, :directory, :repo_name
+    attr_reader :name, :stack, :directory, :repo_name, :app_config
 
     class FailedDeploy < StandardError
       def initialize(app, output)

--- a/lib/hatchet/test_run.rb
+++ b/lib/hatchet/test_run.rb
@@ -160,6 +160,8 @@ module Hatchet
         app_json["environments"]                       ||= {}
         app_json["environments"]["test"]               ||= {}
         app_json["environments"]["test"]["buildpacks"] = @buildpacks.map {|b| { url: b } }
+        app_json["environments"]["test"]["env"]        ||= {}
+        app_json["environments"]["test"]["env"]        = @app.app_config.merge(app_json["environments"]["test"]["env"]) # copy in explicitly set app config
         app_json["stack"]                              ||= @app.stack if @app.stack && !@app.stack.empty?
         File.open("app.json", "w") {|f| f.write(JSON.generate(app_json)) }
 

--- a/lib/hatchet/test_run.rb
+++ b/lib/hatchet/test_run.rb
@@ -160,6 +160,7 @@ module Hatchet
         app_json["environments"]                       ||= {}
         app_json["environments"]["test"]               ||= {}
         app_json["environments"]["test"]["buildpacks"] = @buildpacks.map {|b| { url: b } }
+        app_json["stack"]                              ||= @app.stack if @app.stack && !@app.stack.empty?
         File.open("app.json", "w") {|f| f.write(JSON.generate(app_json)) }
 
         `tar c . | gzip -9 > slug.tgz`

--- a/test/hatchet/ci_too_test.rb
+++ b/test/hatchet/ci_too_test.rb
@@ -3,9 +3,17 @@ require 'test_helper'
 # Split out to be faster
 class CITestToo < Minitest::Test
   def test_ci_create_app_with_stack
-    Hatchet::GitApp.new("rails5_ruby_schema_format").run_ci do |test_run|
+    app = Hatchet::GitApp.new("rails5_ruby_schema_format")
+    app.run_ci do |test_run|
       assert_match "Ruby buildpack tests completed successfully", test_run.output
       assert_equal :succeeded, test_run.status
+      refute_nil app.pipeline_id
+
+      api_rate_limit = app.api_rate_limit.call
+      couplings = api_rate_limit.pipeline_coupling.list_by_pipeline(app.pipeline_id)
+      coupled_app = api_rate_limit.app.info(couplings.first["app"]["id"])
+      assert_equal app.name, coupled_app["name"]
     end
+    assert_nil app.pipeline_id
   end
 end


### PR DESCRIPTION
- write the stack into `app.json` if set, otherwise tests always run on heroku-18
- copy app config into the `test` `env` in `app.json`, so config set on the app makes it into the test run
- couple the app to the CI pipeline, otherwise the pipeline has no apps after the CI run finishes (test run app gets deleted after run), and that'll purge the pipeline, leading to 403s on CI run progress poll or in pipeline deletion