### PR TITLE
Use TRAVIS_PULL_REQUEST_BRANCH over TRAVIS_BRANCH if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix branch resolution on Travis when a pull-request is tested (https://github.com/heroku/hatchet/pull/70)
+
 ## 4.1.0
 
 - Fix CI 403 errors caused by Heroku auto deleting pipelines that do not have an app attached (https://github.com/heroku/hatchet/pull/68)

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -26,7 +26,12 @@ module Hatchet
   Runner  = Hatchet::GitApp
 
   def self.git_branch
+    # TRAVIS_BRANCH works fine unless the build is a pull-request. In that case, it will contain the target branch
+    # not the actual pull-request branch! TRAVIS_PULL_REQUEST_BRANCH contains the correct branch but will be empty
+    # for push builds. See: https://docs.travis-ci.com/user/environment-variables/
+    return ENV['TRAVIS_PULL_REQUEST_BRANCH'] if ENV['TRAVIS_PULL_REQUEST_BRANCH'] && !ENV['TRAVIS_PULL_REQUEST_BRANCH'].empty?
     return ENV['TRAVIS_BRANCH'] if ENV['TRAVIS_BRANCH']
+
     out = `git describe --contains --all HEAD`.strip
     raise "Attempting to find current branch name. Error: Cannot describe git: #{out}" unless $?.success?
     out


### PR DESCRIPTION
If `HATCHET_BUILDPACK_BRANCH` nor `HEROKU_TEST_RUN_BRANCH` are set, Hatchet falls back to `Hatchet.git_branch` which tries to resolve the branch using git. Before using actual git, it will look for the `TRAVIS_BRANCH` environment variable and use its value if available instead.

`TRAVIS_BRANCH` works fine unless the build is a pull-request. In that case, it will contain the target branch not the actual pull-request branch. This results in Hatchet tests running silently against the target branch (most of the time `master`) and not testing the actual changes in the PR. `TRAVIS_PULL_REQUEST_BRANCH` contains the correct branch but will be empty for push builds. 

See: https://docs.travis-ci.com/user/environment-variables/