### PR TITLE
[Close #71] Do not escape to local system shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## 5.0.0
+
 - Shelling out to `heroku` commands no longer uses `Bundler.with_clean_env` (https://github.com/heroku/hatchet/pull/74)
 - CI runs can now happen multiple times against the same app/pipeline (https://github.com/heroku/hatchet/pull/75)
 - Breaking change: Do not allow App#run to escape to system shell by default (https://github.com/heroku/hatchet/pull/72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - Shelling out to `heroku` commands no longer uses `Bundler.with_clean_env` (https://github.com/heroku/hatchet/pull/74)
 - CI runs can now happen multiple times against the same app/pipeline (https://github.com/heroku/hatchet/pull/75)
+- Breaking change: Do not allow App#run to escape to system shell by default (https://github.com/heroku/hatchet/pull/72)
+
+> Note: If you were relying on this behavior, use the `raw: true` option.
+
+- ReplRunner use with App#run is now deprecated (https://github.com/heroku/hatchet/pull/72)
+- Calling App#run with a nil in the second argument is now deprecated (https://github.com/heroku/hatchet/pull/72)
 
 ## 4.1.2
 

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -120,10 +120,12 @@ module Hatchet
         command = cmd_type.to_s
       when nil
         STDERR.puts "Calling App#run with an explicit nil value in the second argument is deprecated."
-        STDERR.puts "You can pass in a hash directly as the second argument now.\n#{caller}"
+        STDERR.puts "You can pass in a hash directly as the second argument now.\n#{caller.join("\n")}"
         command = cmd_type.to_s
       when DefaultCommand
         command = cmd_type.to_s
+      else
+        command = command.to_s
       end
       command = command.shellescape unless options.delete(:raw)
 

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "4.1.2"
+  VERSION = "5.0.0"
 end

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -73,15 +73,21 @@ class AppTest < Minitest::Test
     app.deploy do
       assert_match(/ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/, app.run("ls -a Gemfile 'foo bar #baz'"))
       assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
+      sleep(4) # Dynos don't exit right away and free dynos can't have more than one running at a time, wait before calling `run` again
 
       app.run("ls erpderp", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption } } )
       assert (0 == $?.exitstatus) # $? is from the app.run use of backticks, but we asked the CLI not to return the program exit status by skipping the default "exit-code" option
+      sleep(4)
 
       app.run("ls erpderp", { :heroku => { "no-tty" => nil } } )
       assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
+      sleep(4)
 
       assert_match(/ohai world/, app.run('echo \$HELLO \$NAME', { raw: true, :heroku => { "env" => "HELLO=ohai;NAME=world" } } ))
+      sleep(4)
+
       refute_match(/ohai world/, app.run('echo \$HELLO \$NAME', { raw: true, :heroku => { "env" => "" } } ))
+      sleep(4)
 
       random_name = SecureRandom.hex
       assert_match(/#{random_name}/, app.run("mkdir foo; touch foo/#{random_name}; ls foo/"))

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -73,16 +73,18 @@ class AppTest < Minitest::Test
     app.deploy do
       assert_match(/ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/, app.run("ls -a Gemfile 'foo bar #baz'"))
       assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
-      sleep(3)
-      app.run("ls erpderp", nil, { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption } } )
+
+      app.run("ls erpderp", { :heroku => { "exit-code" => Hatchet::App::SkipDefaultOption } } )
       assert (0 == $?.exitstatus) # $? is from the app.run use of backticks, but we asked the CLI not to return the program exit status by skipping the default "exit-code" option
-      sleep(3)
-      app.run("ls erpderp", nil, { :heroku => { "no-tty" => nil } } )
+
+      app.run("ls erpderp", { :heroku => { "no-tty" => nil } } )
       assert (0 != $?.exitstatus) # $? is from the app.run use of backticks
-      sleep(3)
-      assert_match(/ohai world/, app.run('echo \$HELLO \$NAME', nil, { :heroku => { "env" => "HELLO=ohai;NAME=world" } } ))
-      sleep(3)
-      refute_match(/ohai world/, app.run('echo \$HELLO \$NAME', nil, { :heroku => { "env" => "" } } ))
+
+      assert_match(/ohai world/, app.run('echo \$HELLO \$NAME', { raw: true, :heroku => { "env" => "HELLO=ohai;NAME=world" } } ))
+      refute_match(/ohai world/, app.run('echo \$HELLO \$NAME', { raw: true, :heroku => { "env" => "" } } ))
+
+      random_name = SecureRandom.hex
+      assert_match(/#{random_name}/, app.run("mkdir foo; touch foo/#{random_name}; ls foo/"))
     end
   end
 end


### PR DESCRIPTION
Right now if someone wrote this code:

```
app.run("ls && rm -rf /")
```

It would be interpreted as:

```
$ heroku run ls
$ rm -rf /
```

Which is surprising at best and harmful at worst. This PR auto escapes commands by default. This was the default behavior before https://github.com/heroku/hatchet/pull/58/commits/59f76d487470cd7815b4bd3c35225d8aa1b93d4c which removed shellescape-ing, but this edge case was not considered.

If the user wants more flexibility, they can specify they're using their own escaping by passing in `raw: true`.

I also updated the method signature for `App#run` so that the `heroku:` option can be used without having to specify a `nil` argument in the middle, I'm deprecating the ReplRunner interface (which was pretty broken and I don't believe used) so that we can simplify the method signature in the future.