### PR TITLE
Add alias for Hatchet::App.default_buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Hatchet::App.default_buildpack is aliased to `:default` symbol while passing in buildpacks as an array to Hatchet::App (https://github.com/heroku/hatchet/pull/73)
+
 ## 4.1.1
 
 - Fix branch resolution on Travis when a pull-request is tested (https://github.com/heroku/hatchet/pull/70)

--- a/README.md
+++ b/README.md
@@ -187,12 +187,16 @@ def test_deploy
   # ...
 ```
 
-You can specify multiple buildpacks by passing in an array.
-
-You can use `Hatchet::App.default_buildpack` to get the buildpack URL and branch specified by environment variables:
+You can specify multiple buildpacks by passing in an array. When you do that you also need to tell hatchet where to place your buildpack. Since hatchet needs to build your buildpack from a branch you should not hardcode a path like `heroku/ruby` instead Hatchet has a replacement mechanism. Use the `:default` symbol where you want your buildpack to execute. For example:
 
 ```
-Hatchet::Runner.new("default_ruby", buildpacks: [Hatchet::App.default_buildpack, "https://github.com/pgbouncer/pgbouncer"])
+Hatchet::Runner.new("default_ruby", buildpacks: [:default, "https://github.com/pgbouncer/pgbouncer"])
+```
+
+That will expand your buildpack and branch. For example if you're on the `update_readme` branch of the `heroku-buildpack-ruby` buildpack it would expand to:
+
+```
+Hatchet::Runner.new("default_ruby", buildpacks: ["https://github.com/heroku/heroku-buildpack-ruby#update_readme", "https://github.com/pgbouncer/pgbouncer"])
 ```
 
 You can also specify a stack:

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -9,7 +9,7 @@ module Hatchet
     HATCHET_BUILDPACK_BRANCH = -> { ENV['HATCHET_BUILDPACK_BRANCH'] || ENV['HEROKU_TEST_RUN_BRANCH'] || Hatchet.git_branch }
     BUILDPACK_URL = "https://github.com/heroku/heroku-buildpack-ruby.git"
 
-    attr_reader :name, :stack, :directory, :repo_name, :app_config
+    attr_reader :name, :stack, :directory, :repo_name, :app_config, :buildpacks
 
     class FailedDeploy < StandardError
       def initialize(app, output)
@@ -45,6 +45,8 @@ module Hatchet
       @labs          = ([] << labs).flatten.compact
       @buildpacks    = buildpack || buildpacks || buildpack_url || self.class.default_buildpack
       @buildpacks    = Array(@buildpacks)
+      @buildpacks.map! {|b| b == :default ? self.class.default_buildpack : b}
+
       @before_deploy = before_deploy
       @app_config    = config
       @reaper        = Reaper.new(api_rate_limit: api_rate_limit)

--- a/test/hatchet/app_test.rb
+++ b/test/hatchet/app_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class AppTest < Minitest::Test
+  def test_app_with_default
+    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
+    assert_match "https://github.com/heroku/heroku-buildpack-ruby", app.buildpacks.first
+  end
+
   def test_create_app_with_stack
     stack = "heroku-16"
     app = Hatchet::App.new("default_ruby", stack: stack)
@@ -62,7 +67,7 @@ class AppTest < Minitest::Test
       end
     end
   end
-  
+
   def test_run
     app = Hatchet::GitApp.new("default_ruby")
     app.deploy do


### PR DESCRIPTION
It's really hard to remember `Hatchet::App.default_buildpack` and it's a lot to type. This PR adds the ability to pass in a symbol `:default` that will be expanded to `Hatchet::App.default_buildpack` in the buildpacks array.