### PR TITLE
Allow for Test re-runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 - Shelling out to `heroku` commands no longer uses `Bundler.with_clean_env` (https://github.com/heroku/hatchet/pull/74)
+- CI runs can now happen multiple times against the same app/pipeline (https://github.com/heroku/hatchet/pull/75)
 
 ## 4.1.2
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,10 @@ Hatchet supports testing Heroku CI.
 ```ruby
 Hatchet::Runner.new("rails5_ruby_schema_format").run_ci do |test_run|
   assert_match "Ruby buildpack tests completed successfully", test_run.output
+
+  test_run.run_again # Runs tests again, for example to make sure the cache was used
+
+  assert_match "Using rake", test_run.output
 end
 ```
 

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -6,7 +6,7 @@
 - - test/fixtures/repos/ci/rails5_ruby_schema_format
   - 3e63c3e13f435cf4ab11265e9abd161cc28cc552
 - - test/fixtures/repos/default/default_ruby
-  - da748a59340be8b950e7bbbfb32077eb67d70c3c
+  - 6e642963acec0ff64af51bd6fba8db3c4176ed6e
 - - test/fixtures/repos/lock/lock_fail
   - da748a59340be8b950e7bbbfb32077eb67d70c3c
 - - test/fixtures/repos/rails2/rails2blog

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -319,12 +319,15 @@ module Hatchet
         app:            self,
         pipeline:       @pipeline_id,
         api_rate_limit: api_rate_limit
-     )
+      )
+      in_directory do
+        call_before_deploy
 
-      Hatchet::RETRIES.times.retry do
-        test_run.create_test_run
+        Hatchet::RETRIES.times.retry do
+          test_run.create_test_run
+        end
+        test_run.wait!(&block)
       end
-      test_run.wait!(&block)
     ensure
       delete_pipeline(@pipeline_id) if @pipeline_id
       @pipeline_id = nil

--- a/test/hatchet/ci_four_test.rb
+++ b/test/hatchet/ci_four_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class CIFourTest < Minitest::Test
+  def test_error_with_bad_app
+    string = SecureRandom.hex
+    Hatchet::GitApp.new("default_ruby").run_ci do |test_run|
+      refute_match(string, test_run.output)
+      assert_match("Installing rake" , test_run.output)
+
+      run!(%Q{echo 'puts "#{string}"' >> Rakefile})
+      test_run.run_again
+
+      assert_match(string, test_run.output)
+      assert_match("Using rake" , test_run.output)
+
+      refute_match("Installing rake" , test_run.output)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,3 +20,9 @@ end
 ENV['HATCHET_BUILDPACK_BRANCH'] = "master"
 
 require 'parallel_tests/test/runtime_logger' if ENV['RECORD_RUNTIME']
+
+def run!(cmd)
+  out = `#{cmd}`
+  raise "Error running #{cmd}, output: #{out}" unless $?.success?
+  out
+end


### PR DESCRIPTION
I needed to run a test twice to assert that the cache was used for the Ruby buildpack. I hacked it:

https://github.com/heroku/heroku-buildpack-ruby/blob/facd23708feff15d5bdbfd0455dc470a21b11a76/spec/hatchet/ci_spec.rb#L41-L43

This PR gives a supported API instead to call `TestRun#run_again`.

While working on this, I discovered that the test run wasn't being run inside the temp directory. So I fixed that bug, I also added support for `before_deploy`.