### PR TITLE
Allow using `master` as a lock target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 5.0.3
+
+- Allow repos to be "locked" to master instead of a specific commit (https://github.com/heroku/hatchet/pull/80)
+
 ## 5.0.2
 
 - Fix `before_deploy` use with ci test runs (https://github.com/heroku/hatchet/pull/78)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ Be careful when including repos inside of your test directory. If you're using a
 
 When basing tests on external repos, do not change the tests or they may spontaneously fail. We may create a hatchet.lockfile or something to declare the commit in the future.
 
+When you run `hatchet install` it will lock all the Repos to a specific commit. This is done so that if a repo changes upstream that introduces an error the test suite won't automatically pick it up. For example in https://github.com/sharpstone/lock_fail/commit/e61ba47043fbae131abb74fd74added7e6e504df an error is added, but this will only cause a failure if your project intentionally locks to commit `e61ba47043fbae131abb74fd74added7e6e504df` or later.
+
+You can re-lock your projects by running `hatchet lock`. This modifies the `hatchet.lock` file. For example:
+
+```
+---
+- - test/fixtures/repos/bundler/no_lockfile
+  - 1947ce9a9c276d5df1c323b2ad78d1d85c7ab4c0
+- - test/fixtures/repos/ci/rails5_ci_fails_no_database
+  - 3044f05febdfbbe656f0f5113cf5968ca07e34fd
+- - test/fixtures/repos/ci/rails5_ruby_schema_format
+  - 3e63c3e13f435cf4ab11265e9abd161cc28cc552
+- - test/fixtures/repos/default/default_ruby
+  - 6e642963acec0ff64af51bd6fba8db3c4176ed6e
+- - test/fixtures/repos/lock/lock_fail
+  - da748a59340be8b950e7bbbfb32077eb67d70c3c
+- - test/fixtures/repos/lock/lock_fail_master
+  - master
+- - test/fixtures/repos/rails2/rails2blog
+  - b37357a498ae5e8429f5601c5ab9524021dc2aaa
+- - test/fixtures/repos/rails3/rails3_mri_193
+  - 88c5d0d067cfd11e4452633994a85b04627ae8c7
+```
+
+If you don't want to lock a specific commit, you can instead specify `master` and it will always grab the latest commits.
+
 
 ## Deploying apps
 

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -67,6 +67,7 @@ class HatchetCLI < Thor
   desc "locks to specific git commits", "updates hatchet.lock"
   def lock
     lock_hash = {}
+    lockfile_hash = load_lockfile
     dirs.map do |directory, git_repo|
       Threaded.later do
         puts "== locking #{directory}"
@@ -75,8 +76,12 @@ class HatchetCLI < Thor
           clone(directory, git_repo, quiet: false)
         end
 
-        commit = commit_at_directory(directory)
-        lock_hash[directory] = commit
+        if lockfile_hash[directory] == "master"
+          lock_hash[directory] = "master"
+        else
+          commit = commit_at_directory(directory)
+          lock_hash[directory] = commit
+        end
       end
     end.map(&:join)
 

--- a/hatchet.json
+++ b/hatchet.json
@@ -10,5 +10,8 @@
               "sharpstone/rails5_ruby_schema_format",
               "sharpstone/rails5_ci_fails_no_database"
  ],
- "lock": ["sharpstone/lock_fail"]
+ "lock": [
+   "sharpstone/lock_fail",
+   "sharpstone/lock_fail_master"
+ ]
 }

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -9,6 +9,8 @@
   - 6e642963acec0ff64af51bd6fba8db3c4176ed6e
 - - test/fixtures/repos/lock/lock_fail
   - da748a59340be8b950e7bbbfb32077eb67d70c3c
+- - test/fixtures/repos/lock/lock_fail_master
+  - master
 - - test/fixtures/repos/rails2/rails2blog
   - b37357a498ae5e8429f5601c5ab9524021dc2aaa
 - - test/fixtures/repos/rails3/rails3_mri_193

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "5.0.2"
+  VERSION = "5.0.3"
 end

--- a/test/hatchet/lock_test.rb
+++ b/test/hatchet/lock_test.rb
@@ -6,4 +6,13 @@ class LockTest < Minitest::Test
       assert app.deployed?
     end
   end
+
+  def test_app_with_failure_can_be_locked_to_master
+    puts `bundle exec hatchet lock`
+
+    lock = YAML.load_file("hatchet.lock")
+    name, branch = lock.select {|k,v| k.end_with?("lock_fail_master") }.first
+    assert_equal "test/fixtures/repos/lock/lock_fail_master", name
+    assert_equal "master", branch
+  end
 end


### PR DESCRIPTION
Currently `hatchet lock` locks all repos to a specific commit, but there are times where a maintainer wants the latest commit instead of a specific version. For example if the ruby buildpack maintainer wanted to make sure that the `ruby-getting-started` app.