### PR TITLE
[close #92] Fail on release failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## HEAD
 
-## 7.0.0
-
 - Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)
 
 ## 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 7.0.0
+
+- Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)
+
 ## 6.0.0
 
 - Rate throttling is now provided directly by `platform-api` (https://github.com/heroku/hatchet/pull/82)

--- a/hatchet.gemspec
+++ b/hatchet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "platform-api",  "3.0.0.pre.1 "
+  gem.add_dependency "platform-api",  "~> 3"
   gem.add_dependency "rrrretry",      "~> 1"
   gem.add_dependency "excon",         "~> 0"
   gem.add_dependency "thor",          "~> 0"

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -11,12 +11,24 @@ module Hatchet
 
     attr_reader :name, :stack, :directory, :repo_name, :app_config, :buildpacks
 
-    class FailedDeploy < StandardError
+    class FailedDeploy < StandardError; end
+
+    class FailedDeployError < FailedDeploy
       def initialize(app, output)
-        msg = "Could not deploy '#{app.name}' (#{app.repo_name}) using '#{app.class}' at path: '#{app.directory}'\n" <<
-              " if this was expected add `allow_failure: true` to your deploy hash.\n" <<
-              "output:\n" <<
-              "#{output}"
+        msg = "Could not deploy '#{app.name}' (#{app.repo_name}) using '#{app.class}' at path: '#{app.directory}'\n"
+        msg << "if this was expected add `allow_failure: true` to your deploy hash.\n"
+        msg << "output:\n"
+        msg << "#{output}"
+        super(msg)
+      end
+    end
+
+    class FailedReleaseError < FailedDeploy
+      def initialize(app, output)
+        msg = "Could not release '#{app.name}' (#{app.repo_name}) using '#{app.class}' at path: '#{app.directory}'\n"
+        msg << "if this was expected add `allow_failure: true` to your deploy hash.\n"
+        msg << "output:\n"
+        msg << "#{output}"
         super(msg)
       end
     end

--- a/lib/hatchet/git_app.rb
+++ b/lib/hatchet/git_app.rb
@@ -8,7 +8,12 @@ module Hatchet
     def push_without_retry!
       output = `git push #{git_repo} master 2>&1`
       if !$?.success?
-        raise FailedDeploy.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}\n#{output}") unless @allow_failure
+        raise FailedDeployError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}\n#{output}") unless @allow_failure
+      end
+
+      releases = platform_api.release.list(name)
+      if releases.last["status"] == "failed"
+        raise FailedReleaseError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}\n#{output}") unless @allow_failure
       end
       return output
     end

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "6.0.0"
+  VERSION = "7.0.0"
 end

--- a/spec/hatchet/allow_failure_git_spec.rb
+++ b/spec/hatchet/allow_failure_git_spec.rb
@@ -1,6 +1,30 @@
 require("spec_helper")
 
 describe "AllowFailureGitTest" do
+  describe "release failures" do
+    let(:release_fail_proc) {
+      Proc.new do
+        File.open("Procfile", "w+") do |f|
+          f.write <<~EOM
+            release: echo "failing on release" && exit 1
+          EOM
+        end
+      end
+    }
+
+    it "is marked as a failure if the release fails" do
+      expect {
+        Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc).deploy
+      }.to(raise_error(Hatchet::App::FailedReleaseError))
+    end
+
+    it "works when failure is allowed" do
+      Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc, allow_failure: true).deploy do |app|
+        expect(app.output).to match("failing on release")
+      end
+    end
+  end
+
   it "allowed failure" do
     Hatchet::GitApp.new("no_lockfile", allow_failure: true).deploy do |app|
       puts app.output
@@ -10,6 +34,8 @@ describe "AllowFailureGitTest" do
   end
 
   it "failure with no flag" do
-    expect { Hatchet::GitApp.new("no_lockfile").deploy }.to(raise_error(Hatchet::App::FailedDeploy))
+    expect {
+      Hatchet::GitApp.new("no_lockfile").deploy
+    }.to(raise_error(Hatchet::App::FailedDeploy))
   end
 end


### PR DESCRIPTION
When a release fails to execute the app is never deployed, for example if you were to run:

```ruby
git push heroku master && heroku run ls
```

Both commands will run, but `heroku run ls` will be empty since the release never finished. This creates weird to debug hatchet tests as the deploy will work but any subsequent `app.run(<cmd>)` will fail in strange ways. You can see an example of a failure in #92.


This PR seeks to make this behavior more explicit, by explicitly failing on an incomplete release. This is a breaking change so it's a major version bump.

