### PR TITLE
Allow multiple concurrent one-off dynos to run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ references:
     run:
       name: Run test suite
       command: PARALLEL_SPLIT_TEST_PROCESSES=25 bundle exec parallel_split_test spec/
+      environment:
+        HATCHET_EXPENSIVE_MODE: 1 # !!!! WARNING !!!! ONLY RUN THIS IF YOU WORK FOR HEROKU !!!! WARNING !!!!
   restore: &restore
     restore_cache:
       keys:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps ()
 - Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
 - Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)
 - The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -337,8 +337,9 @@ module Hatchet
         platform_api.formation.update(name, "web", {"size" => "free"})
       end
 
-      @app_update_info = platform_api.app.update(name, { maintenance: true })
-      @reaper.cycle
+    ensure
+      @app_update_info = platform_api.app.update(name, { maintenance: true }) if @app_is_setup
+      @reaper.cycle if @app_is_setup
     end
 
     def in_directory(directory = self.directory)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -54,6 +54,7 @@ module Hatchet
                    buildpacks: nil,
                    buildpack_url: nil,
                    before_deploy: nil,
+                   run_multi: ENV["HATCHET_RUN_MULTI"],
                    config: {}
                   )
       @repo_name     = repo_name
@@ -66,6 +67,12 @@ module Hatchet
       @buildpacks    = buildpack || buildpacks || buildpack_url || self.class.default_buildpack
       @buildpacks    = Array(@buildpacks)
       @buildpacks.map! {|b| b == :default ? self.class.default_buildpack : b}
+      @run_multi = run_multi
+
+      if run_multi && !ENV["HATCHET_EXPENSIVE_MODE"]
+        raise "You're attempting to enable `run_multi: true` mode, but have not enabled `HATCHET_EXPENSIVE_MODE=1` env var to verify you understand the risks"
+      end
+      @run_multi_array = []
       @already_in_dir = nil
       @app_is_setup = nil
 
@@ -147,6 +154,28 @@ module Hatchet
       else
         command = command.to_s
       end
+
+      heroku_command = build_heroku_command(command, options)
+
+      allow_run_multi! if @run_multi
+      if block_given?
+        STDERR.puts "Using App#run with a block is deprecated, support for ReplRunner is being removed.\n#{caller}"
+        # When we deprecated this we can get rid of the "cmd_type" from the method signature
+        require 'repl_runner'
+        return ReplRunner.new(cmd_type, heroku_command, options).run(&block)
+      end
+
+      output = ""
+
+      ShellThrottle.new(platform_api: @platform_api).call do |throttle|
+        output = `#{heroku_command}`
+        throw(:throttle) if output.match?(/reached the API rate limit/)
+      end
+
+      return output
+    end
+
+    private def build_heroku_command(command, options = {})
       command = command.shellescape unless options.delete(:raw)
 
       default_options = { "app" => name, "exit-code" => nil }
@@ -156,22 +185,77 @@ module Hatchet
         arg << "=#{v.to_s.shellescape}" unless v.nil? # nil means we include the option without an argument
         arg
       end.join(" ")
-      heroku_command = "heroku run #{heroku_options} -- #{command}"
 
-      if block_given?
-        STDERR.puts "Using App#run with a block is deprecated, support for ReplRunner is being removed.\n#{caller}"
-        # When we deprecated this we can get rid of the "cmd_type" from the method signature
-        require 'repl_runner'
-        return ReplRunner.new(cmd_type, heroku_command, options).run(&block)
+      "heroku run #{heroku_options} -- #{command}"
+    end
+
+    private def allow_run_multi!
+      raise "Must explicitly enable the `run_multi: true` option. This requires scaling up a dyno and is not free, it may incur charges on your account" unless @run_multi
+
+      @run_multi_is_setup ||= platform_api.formation.update(name, "web", {"size" => "Standard-1X"})
+    end
+
+
+    # Allows multiple commands to be run concurrently in the background.
+    #
+    # WARNING! Using the feature requres that the underlying app is not on the "free" Heroku
+    # tier. This requires scaling up the dyno which is not free. If an app is
+    # scaled up and left in that state it can incur large costs.
+    #
+    # Enabling this feature should be done with extreme caution.
+    #
+    # Example:
+    #
+    #    Hatchet::Runner.new("default_ruby", run_multi: true)
+    #      app.run_multi("ls") { |out| expect(out).to include("Gemfile") }
+    #      app.run_multi("ruby -v") { |out| expect(out).to include("ruby") }
+    #    end
+    #
+    # This example will run `heroku run ls` as well as `ruby -v` at the same time in the background.
+    # The return result will be yielded to the block after they finish running.
+    #
+    # Order of execution is not guaranteed.
+    #
+    # If you need to assert a command was successful, you can yield a second status object like this:
+    #
+    #    Hatchet::Runner.new("default_ruby", run_multi: true)
+    #      app.run_multi("ls") do |out, status|
+    #        expect(status.success?).to be_truthy
+    #        expect(out).to include("Gemfile")
+    #      end
+    #      app.run_multi("ruby -v") do |out, status|
+    #        expect(status.success?).to be_truthy
+    #        expect(out).to include("ruby")
+    #      end
+    #    end
+    def run_multi(command, options = {}, &block)
+      raise "Block required" if block.nil?
+      allow_run_multi!
+
+      run_thread = Thread.new do
+        heroku_command = build_heroku_command(command, options)
+
+        out = nil
+        status = nil
+        ShellThrottle.new(platform_api: @platform_api).call do |throttle|
+          out = `#{heroku_command}`
+          throw(:throttle) if output.match?(/reached the API rate limit/)
+          status = $?
+        end
+
+        yield out, status
+
+        # if block.arity == 1
+        #   block.call(out)
+        # else
+        #   block.call(out, status)
+        # end
       end
-      output = ""
+      run_thread.abort_on_exception = true
 
-      ShellThrottle.new(platform_api: @platform_api).call do |throttle|
-        output = `#{heroku_command}`
-        throw(:throttle) if output.match?(/reached the API rate limit/)
-      end
+      @run_multi_array << run_thread
 
-      return output
+      true
     end
 
     # set debug: true when creating app if you don't want it to be
@@ -248,8 +332,12 @@ module Hatchet
     def teardown!
       return false unless @app_is_setup
 
-      @app_update_info = platform_api.app.update(name, { maintenance: true })
+      if @run_multi_is_setup
+        @run_multi_array.map(&:join)
+        platform_api.formation.update(name, "web", {"size" => "free"})
+      end
 
+      @app_update_info = platform_api.app.update(name, { maintenance: true })
       @reaper.cycle
     end
 

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -175,6 +175,10 @@ module Hatchet
       else
         raise e
       end
+    rescue Excon::Error::Forbidden => e
+      puts "403 random error debugging: " + message
+      puts e.methods
+      raise e
     end
 
     private def hatchet_app_count

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -198,6 +198,7 @@ describe "AppTest" do
     before(:all) do
       skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
 
+      puts "====== YOU SHOULD ONLY SEE THIS ONCE"
       @app = Hatchet::GitApp.new("default_ruby", run_multi: true)
       @app.deploy
     end

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -195,15 +195,15 @@ describe "AppTest" do
   end
 
   describe "running concurrent tests in different examples works" do
-    before(:all) do
+    # Would love for this to be a `before(:all)` however we're hitting this issue: https://github.com/grosser/parallel_split_test/issues/7#issuecomment-668616973
+    before(:each) do
       skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
 
-      puts "====== YOU SHOULD ONLY SEE THIS ONCE"
       @app = Hatchet::GitApp.new("default_ruby", run_multi: true)
       @app.deploy
     end
 
-    after(:all) do
+    after(:each) do
       @app.teardown! if @app
     end
 


### PR DESCRIPTION
By default free apps can only run one "one-off" dyno at a time. For example if you run `heroku run rails c` you cannot run `heroku run ls` until the first command finishes (on a free app). There's a quirk about the distributed nature of the heroku platform in that once `heroku run <command>` returns, it does not guarantee that the dyno has completely been shutdown, but only that shutdown has started. This means that if you're wanting to do multiple `app.run` calls in a test, you need to add sleeps to be safe:

```ruby
Hatchet::Runner.new("default_ruby").deploy do |app|
  expect(app.run("ls -a Gemfile 'foo bar #baz'")).to match(/ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/)
  sleep 4
  expect((0 != $?.exitstatus)).to be_truthy
  app.run("ls erpderp", heroku: ({ "exit-code" => (Hatchet::App::SkipDefaultOption) }))
  sleep 4
  expect((0 == $?.exitstatus)).to be_truthy
  app.run("ls erpderp", heroku: ({ "no-tty" => nil }))
end
```

Which is not great.

## Enable multiple one-off dynos

This PR allows an individual application to flag itself into being able to run multiple concurrent dynos by setting the `run_multi: true` config at initialization time. However, to use this setting you must set the env var `HEROKU_EXPENSIVE_MODE=1` as a safety gate to ensure you understand the risks.

Now the above tests will look like this (without the sleep):

```ruby
Hatchet::Runner.new("default_ruby", run_multi: true).deploy do |app|
  expect(app.run("ls -a Gemfile 'foo bar #baz'")).to match(/ls: cannot access 'foo bar #baz': No such file or directory\s+Gemfile/)
  expect((0 != $?.exitstatus)).to be_truthy

  app.run("ls erpderp", heroku: ({ "exit-code" => (Hatchet::App::SkipDefaultOption) }))
  expect((0 == $?.exitstatus)).to be_truthy

  app.run("ls erpderp", heroku: ({ "no-tty" => nil }))
end
```

NEAT!

## Run multi feature

The REALLY cool feature this opens up is that you no longer have to wait for each of your `heroku run` commands to return. They can now be executed concurrently using the new `run_multi` command:

```ruby
Hatchet::Runner.new("default_ruby", run_multi: true).deploy do |app|
  app.run_multi("ls") do |out, status|
    expect(status.success?).to be_truthy
    expect(out).to include("Gemfile")
  end
  app.run_multi("ruby -v") do |out, status|
    expect(status.success?).to be_truthy
    expect(out).to include("ruby")
  end
end
```

In this example the `heroku run ls` and `heroku run ruby -v` will be executed concurrently. The order that the `run_multi` blocks execute is not guaranteed. 

You can toggle this `run_multi` setting on globally by using `HATCHET_RUN_MULTI=1`. Without this setting enabled, you might need to add a `sleep` between multiple `app.run` invocations. WARNING: Enabling this `run_multi` setting will charge your application account. To work, this requires your application to have a `web` process associated with it.