### PR TITLE
[close #89] Set minimum Time to Live for apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Hatchet created apps no have a configurable minimium time to live based off of setting HATCHET_MINIMUM_TTL_MINUTES=7 (https://github.com/heroku/hatchet/pull/95)
+
 ## 6.0.0
 
 - Rate throttling is now provided directly by `platform-api` (https://github.com/heroku/hatchet/pull/82)

--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ HEROKU_APP_LIMIT=100
 HATCHET_APP_LIMIT=(set to something low like 20 locally, set higher like 80-100 on CI)
 HEROKU_API_KEY=<redacted>
 HEROKU_API_USER=<redacted@redacted.com>
+HATCHET_MINIMUM_TTL_MINUTES=7
 ```
 
 > The syntax to set an env var in Ruby is `ENV["HATCHET_RETRIES"] = "2"` all env vars are strings.
@@ -606,6 +607,7 @@ HEROKU_API_USER=<redacted@redacted.com>
 - `HATCHET_APP_LIMIT`: The maximum number of **hatchet** apps that hatchet will allow in the given account before running the reaper. For local execution keep this low as you don't want your account dominated by hatchet apps. For CI you want it to be much larger, 80-100 since it's not competiting with non-hatchet apps. Your test runner account needs to be a dedicated account.
 - `HEROKU_API_KEY`: The api key of your test account user. If you run locally without this set it will use your personal credentials.
 - `HEROKU_API_USER`: The email address of your user account. If you run locally without this set it will use your personal credentials.
+- `HATCHET_MINIMUM_TTL_MINUTES`: The minimum time that hatchet appplications must be allowed to live on a given account. For example if you set this value to 3 it guarantees that a Hatchet app will be allowed to live 3 minutes before Hatchet will try to delete it. Default is 7 minutes. Set to zero to disable.
 
 ## Basic
 

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -10,11 +10,15 @@ module Hatchet
     HEROKU_APP_LIMIT = Integer(ENV["HEROKU_APP_LIMIT"]  || 100) # the number of apps heroku allows you to keep
     HATCHET_APP_LIMT = Integer(ENV["HATCHET_APP_LIMIT"] || 20)  # the number of apps hatchet keeps around
     DEFAULT_REGEX = /^#{Regexp.escape(Hatchet::APP_PREFIX)}[a-f0-9]+/
+    MINUTES_TO_SECONDS = 60
+    SECONDS_IN_A_DAY = 24 * 60 * 60
+
     attr_accessor :apps
 
     def initialize(api_rate_limit: , regex: DEFAULT_REGEX)
       @api_rate_limit = api_rate_limit
       @regex        = regex
+      @hatchet_apps = []
     end
 
     # Ascending order, oldest is last
@@ -40,7 +44,7 @@ module Hatchet
           # remove our own apps until we are below limit
           destroy_oldest
         else
-          puts "Warning: Reached Heroku app limit of #{HEROKU_APP_LIMIT}."
+          puts "Warning: Reached Heroku app limit: #{@app_count}/#{HEROKU_APP_LIMIT}, hatchet_app_count: #{@hatchet_apps.count}/#{HATCHET_APP_LIMIT}"
           break
         end
       end
@@ -61,8 +65,37 @@ module Hatchet
       mutex.close
     end
 
+    # If you have too many concurrent jobs running you might delete an app that is currently being used
+    # this method enforces a minimum time to live, defaulted to 7 minutes
+    #
+    # If hatchet runs out of apps and the oldest app is younger than 7 minutes old, then it will
+    # sleep until the app can be destroyed.
+    def ensure_app_minimum_ttl(oldest_created_at, time_now: DateTime.now.new_offset(0), jitter_multiplier: rand(1.0..1.05), io: STDOUT)
+      # Comparing DateTime objects returns a fraction of a day, need to convert it into seconds
+      #   https://ruby-doc.org/stdlib-2.6.1/libdoc/date/rdoc/Date.html#method-i-2D
+      time_diff = time_now - DateTime.parse(oldest_created_at)
+      seconds_since_oldest_created = (time_diff * SECONDS_IN_A_DAY).to_i
+
+      minimum_minutes = Integer(ENV.fetch("HATCHET_MINIMUM_TTL_MINUTES", "7"))
+      minimum_seconds = minimum_minutes * MINUTES_TO_SECONDS
+
+      if seconds_since_oldest_created > minimum_seconds
+        # do nothing, App is old enough
+      else
+        time_diff =  minimum_seconds - seconds_since_oldest_created
+        io.puts "Warning: Attempting to destroy an app, but cannot due to minimum time to live. sleeping: #{time_diff}"
+        io.puts "         oldest app created #{seconds_since_oldest_created / 60.0} minutes ago, total app count: #{@app_count}, hatchet app count: #{@hatchet_apps.count}"
+        io.puts "         HATCHET_MINIMUM_TTL_MINUTES=#{minimum_minutes}"
+
+        sleep(time_diff * jitter_multiplier)
+      end
+    end
+
     def destroy_oldest
       oldest = @hatchet_apps.pop
+
+      ensure_app_minimum_ttl(oldest["created_at"])
+
       destroy_by_id(name: oldest["name"], id: oldest["id"], details: "Hatchet app limit: #{HATCHET_APP_LIMT}")
     end
 

--- a/spec/unit/reaper_spec.rb
+++ b/spec/unit/reaper_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe "Reaper" do
+  it "Calculates minimum time to sleep" do
+    reaper = Hatchet::Reaper.new(api_rate_limit: -> (){} )
+    def reaper.sleep(value); @sleep_value = value; end
+    def reaper.what_is_sleep_value; @sleep_value; end
+
+    time_string = "2020-07-28T14:40:00Z"
+    time_now = DateTime.parse(time_string)
+    reaper.ensure_app_minimum_ttl(time_string, time_now: time_now, jitter_multiplier: 1, io: StringIO.new)
+
+    expect(reaper.what_is_sleep_value).to eq(7 * 60)
+  end
+
+  it "does not sleep if app is old enough" do
+    reaper = Hatchet::Reaper.new(api_rate_limit: -> (){} )
+    def reaper.sleep(value); @sleep_value = value; end
+    def reaper.what_is_sleep_value; @sleep_value; end
+
+    time_now = DateTime.parse("2020-07-28T14:47:01Z")
+    reaper.ensure_app_minimum_ttl("2020-07-28T14:40:00Z", time_now: time_now, jitter_multiplier: 1, io: StringIO.new)
+
+    expect(reaper.what_is_sleep_value).to be_nil
+  end
+end


### PR DESCRIPTION
There are cases where Hatchet deletes an app as it is being used/deployed. For example if you've configured a test runner to concurrently execute 25 tests, but you've set HATCHET_APP_LIMIT=20` then one test process will create an app as another is trying to destroy it. This results in odd errors like this in the deploy:

```
       remote: !	No such app as hatchet-t-522c335bea.
```

To prevent this we can set a configurable minimum time to live for applications. In the above scenario where we want to run 25 apps, but have set a maximum of 20 then Hatchet would wait until the oldest app was 7 minutes old before deleting it. This should give the test a chance to finish before continuing and deleting the application.

This value can be configured by the environment variable:

```
HATCHET_MINIMUM_TTL_MINUTES=7
```

When this behavior is triggered a warning is emitted so the developer can investigate and figure out how to re-configure/tune the system so that it doesn't continue to happen.