### PR TITLE
App Reaper Redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+- Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
+- Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)
+- The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)
+- App#deploy without a block will no longer run `teardown!` automatically (https://github.com/heroku/hatchet/pull/97)
 - Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
 - Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)
 

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ end
 
 - `app.in_directory_fork`: Runs the given block in a temp directory and inside of a forked process
 - `app.directory`: Returns the current temp directory the appp is in.
-- `app.deploy`: Your main method, takes a block to execute after the deploy is successful. If no block is provided you must manually call `app.teardown! (see below for an example).
+- `app.deploy`: Your main method, takes a block to execute after the deploy is successful. If no block is provided you must manually call `app.teardown!` (see below for an example).
 - `app.output`: The output contents of the deploy
 - `app.platform_api`: Returns an instance of the [platform-api Heroku client](https://github.com/heroku/platform-api). If hatchet doesn't give you access to a part of Heroku that you need, you can likely do it with the platform-api client.
 - `app.push!`: Push code to your heroku app. Can be used inside of a `deploy` block to re-deploy.

--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ HATCHET_ALIVE_TTL_MINUTES=7
 - `HATCHET_APP_LIMIT`: The maximum number of **hatchet** apps that hatchet will allow in the given account before running the reaper. For local execution keep this low as you don't want your account dominated by hatchet apps. For CI you want it to be much larger, 80-100 since it's not competiting with non-hatchet apps. Your test runner account needs to be a dedicated account.
 - `HEROKU_API_KEY`: The api key of your test account user. If you run locally without this set it will use your personal credentials.
 - `HEROKU_API_USER`: The email address of your user account. If you run locally without this set it will use your personal credentials.
-- `HATCHET_ALIVE_TTL_MINUTES`: The minimum time that hatchet appplications must be allowed to live on a given account if they're not marked by being in maintenance mode. For example if you set this value to 3 it guarantees that a Hatchet app will be allowed to live 3 minutes before Hatchet will try to delete it. Default is 7 minutes. Set to zero to disable.
+- `HATCHET_ALIVE_TTL_MINUTES`: The minimum time that hatchet appplications must be allowed to live on a given account if they're not marked as safe to delete by being in maintenance mode. For example if you set this value to 3 it guarantees that a Hatchet app will be allowed to live 3 minutes before Hatchet will try to delete it. Default is 7 minutes. Set to zero to disable.
 
 ## Basic
 

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ end
 - `app.platform_api`: Returns an instance of the [platform-api Heroku client](https://github.com/heroku/platform-api). If hatchet doesn't give you access to a part of Heroku that you need, you can likely do it with the platform-api client.
 - `app.push!`: Push code to your heroku app. Can be used inside of a `deploy` block to re-deploy.
 - `app.run_ci`: Runs Heroku CI against the app, returns a TestRun object in the block
-- `app.teardown!`: This method is called automatically when using `app.deploy` in block mode after the deploy block finishes. When called it will clean up resources, mark the app as being finished (by setting {maintenance" => true} on the app) so that the reaper knows it is safe to delete later. Here is an example of a test that creates and deploys an app manually, then later tears it down manually. If you deploy an application without calling `teardown!` then Hatchet will not know it is safe to delete and may keep it around for much longer than required for the test to finish.
+- `app.teardown!`: This method is called automatically when using `app.deploy` in block mode after the deploy block finishes. When called it will clean up resources, mark the app as being finished (by setting `{"maintenance" => true}` on the app) so that the reaper knows it is safe to delete later. Here is an example of a test that creates and deploys an app manually, then later tears it down manually. If you deploy an application without calling `teardown!` then Hatchet will not know it is safe to delete and may keep it around for much longer than required for the test to finish.
 
 ```ruby
 before(:all) do

--- a/README.md
+++ b/README.md
@@ -310,11 +310,12 @@ $ heroku run bash -a hatchet-t-bed73940a6
 And use that to debug. Hatchet deletes old apps on demand. You tell it what your limits are and it will stay within those limits:
 
 ```
-HEROKU_APP_LIMIT=100
 HATCHET_APP_LIMIT=20
 ```
 
-With these env vars, Hatchet will "reap" older hatchet apps when it sees there are 20 or more hatchet apps, or if you have 100 or more apps under your user account. For CI, it's recomment you increase the HATCHET_APP_LIMIT to 80-100. If these values are too low and you're running hatchet tests in parallel then one execution of the reaper from one test run might cause an app that is still being used for a test to be deleted.
+With these env vars, Hatchet will "reap" older hatchet apps when it sees there are 20 or more hatchet apps. For CI, it's recomment you increase the HATCHET_APP_LIMIT to 80-100. Hatchet will mark apps as safe for deletion once they've finished and the `teardown!` method has been called on them (it tracks this by enabling maintenance mode on apps). Hatchet only tracks its own apps. If your account has reached the maximum number of global Heroku apps, you'll need to manually remove some.
+
+If for some reason an app is not marked as being in maintenance mode it can be deleted, but only after it has been allowed to live for a period of time. This is configured by the `HATCHET_ALIVE_TTL_MINUTES` env var. For example if you set it for `7` then Hatchet will ensure any apps that are not marked as being in maintenace mode are allowed to live for at least seven minutes. This should give the app time to finish execution of the test so it is not deleted mid-deploy. When this deletion happens, you'll see a warning in your output. It could indicate you're not properly cleaning up and calling `teardown!` on some of your apps, or it could mean that you're attempting to execute more tests concurrently than your `HATCHET_APP_LIMIT` allows. This might happen if you have multiple CI runs executing at the same time.
 
 It's recommend you don't use your personal Heroku API key for running tests on a CI server since the hatchet apps count against your account maximum limits. Running tests using your account locally is fine for debugging one or two tests.
 
@@ -336,11 +337,10 @@ Hatchet::Runner.new("python_default").deploy do |app|
   expect(app.output).to match(/Installing pip/)
 
   # Redeploy with changed requirements file
-  run!(%Q{echo "" >> requirements.txt})
   run!(%Q{echo "pygments" >> requirements.txt})
-  run!(%Q{git add . ; git commit --allow-empty -m next})
+  app.commit!
 
-  app.push!
+  app.push! # <======= HERE
 
   expect(app.output).to match("Requirements file has been changed, clearing cached dependencies")
 end
@@ -349,7 +349,6 @@ end
 ### Testing CI
 
 You can run an app against CI using the `run_ci` command (instead of `deploy`). You can re-run tests against the same app with the `run_again` command.
-
 
 ```ruby
 Hatchet::Runner.new("python_default").run_ci do |test_run|
@@ -576,11 +575,28 @@ end
 
 - `app.in_directory_fork`: Runs the given block in a temp directory and inside of a forked process
 - `app.directory`: Returns the current temp directory the appp is in.
-- `app.deploy`: Your main method, takes a block to execute after the deploy is successful
+- `app.deploy`: Your main method, takes a block to execute after the deploy is successful. If no block is provided you must manually call `app.teardown! (see below for an example).
 - `app.output`: The output contents of the deploy
 - `app.platform_api`: Returns an instance of the [platform-api Heroku client](https://github.com/heroku/platform-api). If hatchet doesn't give you access to a part of Heroku that you need, you can likely do it with the platform-api client.
 - `app.push!`: Push code to your heroku app. Can be used inside of a `deploy` block to re-deploy.
 - `app.run_ci`: Runs Heroku CI against the app, returns a TestRun object in the block
+- `app.teardown!`: This method is called automatically when using `app.deploy` in block mode after the deploy block finishes. When called it will clean up resources, mark the app as being finished (by setting {maintenance" => true} on the app) so that the reaper knows it is safe to delete later. Here is an example of a test that creates and deploys an app manually, then later tears it down manually. If you deploy an application without calling `teardown!` then Hatchet will not know it is safe to delete and may keep it around for much longer than required for the test to finish.
+
+```ruby
+before(:all) do
+  @app = Hatchet::Runner.new("default_ruby")
+  @app.deploy
+end
+
+after(:all) do
+  @app.teardown! if @app
+end
+
+it "uses ruby" do
+  expect(@app.run("ruby -v")).to match("ruby")
+end
+
+```
 - `test_run.run_again`: Runs the app again in Heroku CI
 - `test_run.status`: Returns the status of the CI run (possible values are `:pending`, `:building`, `:creating`, `:succeeded`, `:failed`, `:errored`)
 - `test_run.output`: The output of a given test run
@@ -591,10 +607,10 @@ end
 HATCHET_BUILDPACK_BASE=https://github.com/heroku/heroku-buildpack-nodejs.git
 HATCHET_BUILDPACK_BRANCH=<branch name if you dont want hatchet to set it for you>
 HATCHET_RETRIES=2
-HEROKU_APP_LIMIT=100
 HATCHET_APP_LIMIT=(set to something low like 20 locally, set higher like 80-100 on CI)
 HEROKU_API_KEY=<redacted>
 HEROKU_API_USER=<redacted@redacted.com>
+HATCHET_ALIVE_TTL_MINUTES=7
 ```
 
 > The syntax to set an env var in Ruby is `ENV["HATCHET_RETRIES"] = "2"` all env vars are strings.
@@ -602,10 +618,10 @@ HEROKU_API_USER=<redacted@redacted.com>
 - `HATCHET_BUILDPACK_BASE`: This is the URL where hatchet can find your buildpack. It must be public for Heroku to be able to use your buildpack.
 - `HATCHET_BUILDPACK_BRANCH`: By default Hatchet will use your current git branch name. If for some reason git is not available or you want to manually specify it like `ENV["HATCHET_BUILDPACK_BRANCH'] = ENV[`MY_CI_BRANCH`]` then you can.
 - `HATCHET_RETRIES` If the `ENV['HATCHET_RETRIES']` is set to a number, deploys are expected to work and automatically retry that number of times. Due to testing using a network and random failures, setting this value to `3` retries seems to work well. If an app cannot be deployed within its allotted number of retries, an error will be raised. The downside of a larger number is that your suite will keep running for much longer when there are legitimate failures.
-- `HEROKU_APP_LIMIT`: The maximum number of total apps hatchet will allow in the given account before running the reaper
 - `HATCHET_APP_LIMIT`: The maximum number of **hatchet** apps that hatchet will allow in the given account before running the reaper. For local execution keep this low as you don't want your account dominated by hatchet apps. For CI you want it to be much larger, 80-100 since it's not competiting with non-hatchet apps. Your test runner account needs to be a dedicated account.
 - `HEROKU_API_KEY`: The api key of your test account user. If you run locally without this set it will use your personal credentials.
 - `HEROKU_API_USER`: The email address of your user account. If you run locally without this set it will use your personal credentials.
+- `HATCHET_ALIVE_TTL_MINUTES`: The minimum time that hatchet appplications must be allowed to live on a given account if they're not marked by being in maintenance mode. For example if you set this value to 3 it guarantees that a Hatchet app will be allowed to live 3 minutes before Hatchet will try to delete it. Default is 7 minutes. Set to zero to disable.
 
 ## Basic
 
@@ -631,8 +647,7 @@ end
 
 - **spec/hatchet/buildpack_spec.rb**
 
-Rspec knows a file is a test file or not by the name. It looks for files that end in `_spec.rb` you can have as many as you want. I recommend putting them in a "spec/hatchet" sub-folder.
-
+Rspec knows a file is a test file or not by the name. It looks for files that end in `spec.rb` you can have as many as you want. I recommend putting them in a "spec/hatchet" sub-folder.
 
 - **File contents**
 
@@ -676,7 +691,6 @@ If you want to assert the opposite you can use `to_not`:
 expect(value).to_not eq(false)
 ```
 
-
 - **matcher syntax**
 
 In the above example the `eq` is called a "matcher". You're matching it against an object. In this case you're looking for equality `==`.
@@ -693,7 +707,6 @@ expect(value).to include("there")
 Rspec uses some "magic" to convert anything you pass to
 
 Since most values in hatchet are strings, the ones I use the most are:
-
 
 - Rspec matchers
   - include https://relishapp.com/rspec/rspec-expectations/v/3-2/docs/built-in-matchers/include-matcher#string-usage
@@ -822,7 +835,6 @@ puts my_hash.inspect
 
 Blocks are a concept in Ruby for closure. Depending on how it's used it can be an anonomous method. It's always a method for passing around code. When you see `do |app|` that's the beginning of an implicit block. In addition to an implicit block you can create an explicit block using lambdas and procs. In hatchet, these are most likely to be used to update the app `before_deploy`. Here's an example of some syntax for creating various blocks.
 
-
 ```ruby
 before_deploy = -> { FileUtils.touch("foo.txt") } # This syntax is called a "stabby lambda"
 before_deploy = lambda { FileUtils.touch("foo.txt") } # This is a more verbose lambda
@@ -880,7 +892,6 @@ For more info on commands. If you're using the source code you can run
 the command by going to the source code directory and running:
 
     $ ./bin/hatchet --help
-
 
 ## License
 

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -363,6 +363,7 @@ module Hatchet
         test_run.wait!(&block)
       end
     ensure
+      teardown! if block_given?
       delete_pipeline(@pipeline_id) if @pipeline_id
       @pipeline_id = nil
     end

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -9,7 +9,7 @@ module Hatchet
     HATCHET_BUILDPACK_BRANCH = -> { ENV['HATCHET_BUILDPACK_BRANCH'] || ENV['HEROKU_TEST_RUN_BRANCH'] || Hatchet.git_branch }
     BUILDPACK_URL = "https://github.com/heroku/heroku-buildpack-ruby.git"
 
-    attr_reader :name, :stack, :directory, :repo_name, :app_config, :buildpacks
+    attr_reader :name, :stack, :directory, :repo_name, :app_config, :buildpacks, :reaper
 
     class FailedDeploy < StandardError; end
 
@@ -182,22 +182,24 @@ module Hatchet
     alias :no_debug? :not_debugging?
 
     def deployed?
-      # !heroku.get_ps(name).body.detect {|ps| ps["process"].include?("web") }.nil?
       api_rate_limit.call.formation.list(name).detect {|ps| ps["type"] == "web"}
     end
 
     def create_app
       3.times.retry do
         begin
-          # heroku.post_app({ name: name, stack: stack }.delete_if {|k,v| v.nil? })
           hash = { name: name, stack: stack }
           hash.delete_if { |k,v| v.nil? }
-          api_rate_limit.call.app.create(hash)
+          heroku_api_create_app(hash)
         rescue => e
-          @reaper.cycle
+          @reaper.cycle(app_exception_message: e.message)
           raise e
         end
       end
+    end
+
+    private def heroku_api_create_app(hash)
+      api_rate_limit.call.app.create(hash)
     end
 
     def update_stack(stack_name)
@@ -239,10 +241,9 @@ module Hatchet
 
     def teardown!
       return false unless @app_is_setup
-      if debugging?
-        puts "Debugging App:#{name}"
-        return false
-      end
+
+      @app_update_info = platform_api.app.update(name, { maintenance: true })
+
       @reaper.cycle
     end
 
@@ -285,10 +286,6 @@ module Hatchet
       end
     end
 
-    # creates a new app on heroku, "pushes" via anvil or git
-    # then yields to self so you can call self.run or
-    # self.deployed?
-    # Allow deploy failures on CI server by setting ENV['HATCHET_RETRIES']
     def deploy(&block)
       in_directory do
         self.setup!
@@ -296,7 +293,7 @@ module Hatchet
         block.call(self, api_rate_limit.call, output) if block_given?
       end
     ensure
-      self.teardown!
+      self.teardown! if block_given?
     end
 
     def push

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -1,88 +1,187 @@
 require 'tmpdir'
 
 module Hatchet
-  # Hatchet apps are useful after the tests run for debugging purposes
-  # the reaper is designed to allow the most recent apps to stay alive
-  # while keeping the total number of apps under the global Heroku limit.
-  # Any time you're worried about hitting the limit call @reaper.cycle
+  # This class lazilly deletes hatchet apps
   #
+  # When the reaper is called, it will check if the system has too many apps (Bassed off of HATCHET_APP_LIMIT), if so it will attempt
+  # to delete an app to free up capacity. The goal of lazilly deleting apps is to temporarilly keep
+  # apps around for debugging if they fail.
+  #
+  # When App#teardown! is called on an app it is marked as being in a "finished" state by turning
+  # on maintenance mode. The reaper will delete these in order (oldest first).
+  #
+  # If no apps are marked as being "finished" then the reaper will check to see if the oldest app
+  # has been alive for a long enough period for it's tests to finish (configured by HATCHET_ALIVE_TTL_MINUTES env var).
+  # If the "unfinished" app has been alive that long it will be deleted. If not, the system will sleep for a period of time
+  # in an attempt to allow other apps to move to be "finished".
+  #
+  # This class only limits and the number of "hatchet" apps on the system. Prevously there was a maximum of 100 apps on a
+  # Heroku account. Now a user can belong to multiple orgs and the total number of apps they have access to is no longer
+  # fixed at 100. Instead of hard coding a maximum limit, this failure mode is handled by forcing deletion of
+  # an app when app creation fails. In the future we may find a better way of detecting this failure mode
+  #
+  # Notes:
+  #
+  # - The class uses a file mutex so that multiple processes on the same machine do not attempt to run the
+  #   reaper at the same time.
+  # - AlreadyDeletedError will be raised if an app has already been deleted (possibly by another test run on
+  #   another machine). When this happens, the system will automatically attempt to reap another app.
   class Reaper
-    HEROKU_APP_LIMIT = Integer(ENV["HEROKU_APP_LIMIT"]  || 100) # the number of apps heroku allows you to keep
-    HATCHET_APP_LIMT = Integer(ENV["HATCHET_APP_LIMIT"] || 20)  # the number of apps hatchet keeps around
+    class AlreadyDeletedError < StandardError; end
+
+    HATCHET_APP_LIMIT = Integer(ENV["HATCHET_APP_LIMIT"] || 20)  # the number of apps hatchet keeps around
     DEFAULT_REGEX = /^#{Regexp.escape(Hatchet::APP_PREFIX)}[a-f0-9]+/
-    attr_accessor :apps
 
-    def initialize(api_rate_limit: , regex: DEFAULT_REGEX)
+    attr_accessor :io, :hatchet_app_limit
+
+    def initialize(api_rate_limit: , regex: DEFAULT_REGEX, io: STDOUT, hatchet_app_limit:  HATCHET_APP_LIMIT, initial_sleep: 10)
       @api_rate_limit = api_rate_limit
-      @regex        = regex
+      @regex = regex
+      @io = io
+      @finished_hatchet_apps = []
+      @unfinished_hatchet_apps = []
+      @app_count = 0
+      @hatchet_app_limit = hatchet_app_limit
+      @reaper_throttle = ReaperThrottle.new(initial_sleep: initial_sleep)
     end
 
-    # Ascending order, oldest is last
-    def get_apps
-      apps          = @api_rate_limit.call.app.list.sort_by { |app| DateTime.parse(app["created_at"]) }.reverse
-      @app_count    = apps.count
-      @hatchet_apps = apps.select {|app| app["name"].match(@regex) }
-    end
+    def cycle(app_exception_message: false)
+      # Protect against parallel deletion of the same app on the same system
+      mutex_file = File.open("#{Dir.tmpdir()}/hatchet_reaper_mutex", File::CREAT)
+      mutex_file.flock(File::LOCK_EX)
 
-    def cycle
-      # we don't want multiple Hatchet processes (e.g. when using rspec-parallel) to delete apps at the same time
-      # this could otherwise result in race conditions in API causing errors other than 404s, making tests fail
-      mutex = File.open("#{Dir.tmpdir()}/hatchet_reaper_mutex", File::CREAT)
-      mutex.flock(File::LOCK_EX)
+      refresh_app_list if @finished_hatchet_apps.empty?
 
-      # update list of apps once
-      get_apps
-
-      return unless over_limit?
-
-      while over_limit?
-        if @hatchet_apps.count > 1
-          # remove our own apps until we are below limit
-          destroy_oldest
-        else
-          puts "Warning: Reached Heroku app limit of #{HEROKU_APP_LIMIT}."
-          break
-        end
+      # To be safe try to delete an app even if we're not over the limit
+      # since the exception may have been caused by going over the maximum account limit
+      if app_exception_message
+          io.puts <<~EOM
+            WARNING: Running reaper due to exception on app
+                     #{stats_string}
+                     Exception: #{app_exception_message}
+          EOM
+        reap_once
       end
 
-    # If the app is already deleted an exception
-    # will be raised, if the app cannot be found
-    # assume it is already deleted and try again
+      while over_limit?
+        reap_once
+      end
+    ensure
+      mutex_file.close
+    end
+
+    def stats_string
+      "total_app_count: #{@app_count}, hatchet_app_count: #{hatchet_app_count}/#{HATCHET_APP_LIMIT}, finished: #{@finished_hatchet_apps.length}, unfinished: #{@unfinished_hatchet_apps.length}"
+    end
+
+    def over_limit?
+      hatchet_app_count > hatchet_app_limit
+    end
+
+    # No guardrails, will delete all apps that match the hatchet namespace
+    def destroy_all
+      get_apps
+
+      (@finished_hatchet_apps + @unfinished_hatchet_apps).each do |app|
+        begin
+          destroy_with_log(name: app["name"], id: app["id"])
+        rescue AlreadyDeletedError
+          # Ignore, keep going
+        end
+      end
+    end
+
+    private def reap_once
+      refresh_app_list if @finished_hatchet_apps.empty?
+
+      if (app = @finished_hatchet_apps.pop)
+        destroy_with_log(name: app["name"], id: app["id"])
+      elsif (app = @unfinished_hatchet_apps.pop)
+        destroy_if_old_enough(app)
+      end
+    rescue AlreadyDeletedError
+      retry
+    end
+
+    # Checks to see if the given app is older than the HATCHET_ALIVE_TTL_MINUTES
+    # if so, then the app is deleted, otherwise the reaper sleeps for a period of time after which
+    # It can try again to delete another app. The hope is that some apps will be marked as finished
+    # in that time
+    private def destroy_if_old_enough(app)
+      age = AppAge.new(
+        created_at: app["created_at"],
+        ttl_minutes: ENV.fetch("HATCHET_ALIVE_TTL_MINUTES", "7").to_i
+      )
+      if age.can_delete?
+        io.puts "WARNING: Destroying an app without maintenance mode on, app: #{app["name"]}, app_age: #{age.in_minutes} minutes"
+
+        destroy_with_log(name: app["name"], id: app["id"])
+      else
+        # We're not going to delete it yet, so put it back
+        @unfinished_hatchet_apps << app
+
+        # Sleep, try again later
+        @reaper_throttle.call(min_sleep: age.sleep_for_ttl) do |sleep_for|
+          io.puts <<~EOM
+            WARNING: Attempting to destroy an app without maintenance mode on, but it is not old enough. app: #{app["name"]}, app_age: #{age.in_minutes} minutes
+                     This can happen if App#teardown! is not called on an application, which will leave it in an 'unfinished' state
+                     This can also happen if you're trying to run more tests concurrently than your currently set value for HATCHET_APP_COUNT
+                     Sleeping: #{sleep_for} seconds before trying to find another app to reap"
+                     #{stats_string}, HATCHET_ALIVE_TTL_MINUTES=#{age.ttl_minutes}
+          EOM
+
+          sleep(sleep_for)
+        end
+      end
+    end
+
+    private def get_heroku_apps
+      @api_rate_limit.call.app.list
+    end
+
+    private def refresh_app_list
+      apps = get_heroku_apps.
+        map {|app| app["created_at"] = DateTime.parse(app["created_at"].to_s); app }.
+        sort_by { |app| app["created_at"] }.
+        reverse # Ascending order, oldest is last
+
+      @app_count = apps.length
+
+      @finished_hatchet_apps.clear
+      @unfinished_hatchet_apps.clear
+      apps.each do |app|
+        next unless app["name"].match(@regex)
+
+        if app["maintenance"]
+          @finished_hatchet_apps << app
+        else
+          @unfinished_hatchet_apps << app
+        end
+      end
+    end
+
+    private def destroy_with_log(name:, id:)
+      message = "Destroying #{name.inspect}: #{id}, #{stats_string}"
+
+      @api_rate_limit.call.app.delete(id)
+
+      io.puts message
+
     rescue Excon::Error::NotFound => e
       body = e.response.body
       if body =~ /Couldn\'t find that app./
-        puts "#{@message}, but looks like it was already deleted"
-        mutex.close # ensure only gets called on block exit and not on `retry`
-        retry
-      end
-      raise e
-    ensure
-      # don't forget to close the mutex; this also releases our lock
-      mutex.close
-    end
-
-    def destroy_oldest
-      oldest = @hatchet_apps.pop
-      destroy_by_id(name: oldest["name"], id: oldest["id"], details: "Hatchet app limit: #{HATCHET_APP_LIMT}")
-    end
-
-    def destroy_all
-      get_apps
-      @hatchet_apps.each do |app|
-        destroy_by_id(name: app["name"], id: app["id"])
+        io.puts "Duplicate destoy attempted #{name.inspect}: #{id}"
+        raise AlreadyDeletedError.new
+      else
+        raise e
       end
     end
 
-    def destroy_by_id(name:, id:, details: "")
-      @message = "Destroying #{name.inspect}: #{id}. #{details}"
-      puts @message
-      @api_rate_limit.call.app.delete(id)
-    end
-
-    private
-
-    def over_limit?
-      @app_count > HEROKU_APP_LIMIT || @hatchet_apps.count > HATCHET_APP_LIMT
+    private def hatchet_app_count
+      @finished_hatchet_apps.length + @unfinished_hatchet_apps.length
     end
   end
 end
+
+require_relative "reaper/app_age"
+require_relative "reaper/reaper_throttle"

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -121,7 +121,7 @@ module Hatchet
         @unfinished_hatchet_apps << app
 
         # Sleep, try again later
-        @reaper_throttle.call(min_sleep: age.sleep_for_ttl) do |sleep_for|
+        @reaper_throttle.call(max_sleep: age.sleep_for_ttl) do |sleep_for|
           io.puts <<~EOM
             WARNING: Attempting to destroy an app without maintenance mode on, but it is not old enough. app: #{app["name"]}, app_age: #{age.in_minutes} minutes
                      This can happen if App#teardown! is not called on an application, which will leave it in an 'unfinished' state

--- a/lib/hatchet/reaper/app_age.rb
+++ b/lib/hatchet/reaper/app_age.rb
@@ -1,0 +1,49 @@
+module Hatchet
+  class Reaper
+    # Class for figuring out how old a given time is relative to another time
+    #
+    # Expects inputs as a DateTime instance
+    #
+    # Example:
+    #
+    #   time_now = DateTime.parse("2020-07-28T14:40:00Z")
+    #   age = AppAge.new(created_at: DateTIme.parse("2020-07-28T14:40:00Z"), time_now: time_now, ttl_minutes: 1)
+    #   age.in_minutes => 0.0
+    #   age.too_young_to_die? # => true
+    #   age.can_delete? # => false
+    #   age.sleep_for_ttl #=> 60
+    class AppAge
+      SECONDS_IN_A_DAY = 24 * 60 * 60
+
+      attr_reader :ttl_minutes
+
+      def initialize(created_at:, ttl_minutes:, time_now: DateTime.now.new_offset(0))
+        @seconds_ago = date_time_diff_in_seconds(time_now, created_at)
+        @ttl_minutes = ttl_minutes
+        @ttl_seconds = ttl_minutes * 60
+      end
+
+      def date_time_diff_in_seconds(now, whence)
+        (now - whence) * SECONDS_IN_A_DAY
+      end
+
+      def too_young_to_die?
+        !can_delete?
+      end
+
+      def can_delete?
+        @seconds_ago > @ttl_seconds
+      end
+
+      def sleep_for_ttl
+        return 0 if can_delete?
+
+        @ttl_seconds - @seconds_ago
+      end
+
+      def in_minutes
+        (@seconds_ago / 60.0).round(2)
+      end
+    end
+  end
+end

--- a/lib/hatchet/reaper/reaper_throttle.rb
+++ b/lib/hatchet/reaper/reaper_throttle.rb
@@ -12,19 +12,19 @@ module Hatchet
     # Example:
     #
     #   reaper_throttle = ReaperThrottle.new(initial_sleep: 2)
-    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #   reaper_throttle.call(max_sleep: 5) do |sleep_for|
     #     puts sleep_for # => 2
     #   end
-    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #   reaper_throttle.call(max_sleep: 5) do |sleep_for|
     #     puts sleep_for # => 4
     #   end
-    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #   reaper_throttle.call(max_sleep: 5) do |sleep_for|
     #     puts sleep_for # => 5
     #   end
     #
-    #   # The throttle is now reset since it hit the min_sleep value
+    #   # The throttle is now reset since it hit the max_sleep value
     #
-    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #   reaper_throttle.call(max_sleep: 5) do |sleep_for|
     #     puts sleep_for # => 2
     #   end
     class ReaperThrottle
@@ -33,10 +33,10 @@ module Hatchet
         @sleep_for = @initial_sleep
       end
 
-      def call(min_sleep: )
+      def call(max_sleep: )
         raise "Must call with a block" unless block_given?
 
-        sleep_for = [@sleep_for, min_sleep].min
+        sleep_for = [@sleep_for, max_sleep].min
 
         yield sleep_for
 

--- a/lib/hatchet/reaper/reaper_throttle.rb
+++ b/lib/hatchet/reaper/reaper_throttle.rb
@@ -1,0 +1,55 @@
+module Hatchet
+  class Reaper
+    # This class retains and increments a sleep value between executions
+    #
+    # Every time we pause, we increase the duration of the pause 2x. If we
+    # do not sleep for long enough then we will burn API requests that we don't need to make.
+    #
+    # To help prevent sleeping for too long, the reaper will sleep for a maximum amount of time
+    # equal to the age_sleep_for_ttl. If that happens, it's likely a fairly large value and the
+    # internal incremental value can be reset
+    #
+    # Example:
+    #
+    #   reaper_throttle = ReaperThrottle.new(initial_sleep: 2)
+    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #     puts sleep_for # => 2
+    #   end
+    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #     puts sleep_for # => 4
+    #   end
+    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #     puts sleep_for # => 5
+    #   end
+    #
+    #   # The throttle is now reset since it hit the min_sleep value
+    #
+    #   reaper_throttle.call(min_sleep: 5) do |sleep_for|
+    #     puts sleep_for # => 2
+    #   end
+    class ReaperThrottle
+      def initialize(initial_sleep: )
+        @initial_sleep = initial_sleep
+        @sleep_for = @initial_sleep
+      end
+
+      def call(min_sleep: )
+        raise "Must call with a block" unless block_given?
+
+        sleep_for = [@sleep_for, min_sleep].min
+
+        yield sleep_for
+
+        if sleep_for < @sleep_for
+          reset!
+        else
+          @sleep_for *= 2
+        end
+      end
+
+      def reset!
+        @sleep_for = @initial_sleep
+      end
+    end
+  end
+end

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -57,7 +57,6 @@ describe "AppTest" do
       expect(app.platform_api.app.info(app.name)["maintenance"]).to be_falsey
     end
 
-
     # After the app is updated, there's no guarantee it will still exist
     # so we cannot rely on an api call to determine maintenance mode
     app_update_info = app.instance_variable_get(:"@app_update_info")

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -21,6 +21,22 @@ describe "AppTest" do
     expect(app.what_is_git_push_heroku_yall_call_count).to be(2)
   end
 
+  it "calls reaper if cannot create an app" do
+    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
+    def app.heroku_api_create_app(*args); raise StandardError.new("made you look"); end
+
+    reaper = app.reaper
+
+    def reaper.cycle(app_exception_message: ); @app_exception_message = app_exception_message; end
+    def reaper.recorded_app_exception_message; @app_exception_message; end
+
+    expect {
+      app.create_app
+    }.to raise_error("made you look")
+
+    expect(reaper.recorded_app_exception_message).to match("made you look")
+  end
+
   it "app with default" do
     app = Hatchet::App.new("default_ruby", buildpacks: [:default])
     expect(app.buildpacks.first).to match("https://github.com/heroku/heroku-buildpack-ruby")
@@ -31,6 +47,38 @@ describe "AppTest" do
     app = Hatchet::App.new("default_ruby", stack: stack)
     app.create_app
     expect(app.platform_api.app.info(app.name)["build_stack"]["name"]).to eq(stack)
+  end
+
+  it "marks itself 'finished' when done in block mode" do
+    app = Hatchet::Runner.new("default_ruby")
+
+    def app.push_with_retry!; nil; end
+    app.deploy do |app|
+      expect(app.platform_api.app.info(app.name)["maintenance"]).to be_falsey
+    end
+
+
+    # After the app is updated, there's no guarantee it will still exist
+    # so we cannot rely on an api call to determine maintenance mode
+    app_update_info = app.instance_variable_get(:"@app_update_info")
+    expect(app_update_info["name"]).to eq(app.name)
+    expect(app_update_info["maintenance"]).to be_truthy
+  end
+
+  it "marks itself 'finished' when done in non-block mode" do
+    app = Hatchet::Runner.new("default_ruby")
+
+    def app.push_with_retry!; nil; end
+    app.deploy
+    expect(app.platform_api.app.info(app.name)["maintenance"]).to be_falsey
+
+    app.teardown!
+
+    # After the app is updated, there's no guarantee it will still exist
+    # so we cannot rely on an api call to determine maintenance mode
+    app_update_info = app.instance_variable_get(:"@app_update_info")
+    expect(app_update_info["name"]).to eq(app.name)
+    expect(app_update_info["maintenance"]).to be_truthy
   end
 
   it "before deploy" do

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -4,7 +4,8 @@ describe "CIFourTest" do
   it "error with bad app" do
     string = SecureRandom.hex
 
-    Hatchet::GitApp.new("default_ruby").run_ci do |test_run|
+    app = Hatchet::GitApp.new("default_ruby")
+    app.run_ci do |test_run|
       expect(test_run.output).to_not match(string)
       expect(test_run.output).to match("Installing rake")
 
@@ -14,7 +15,15 @@ describe "CIFourTest" do
       expect(test_run.output).to match(string)
       expect(test_run.output).to match("Using rake")
       expect(test_run.output).to_not match("Installing rake")
+
+      expect(app.platform_api.app.info(app.name)["maintenance"]).to be_falsey
     end
+
+    # After the app is updated, there's no guarantee it will still exist
+    # so we cannot rely on an api call to determine maintenance mode
+    app_update_info = app.instance_variable_get(:"@app_update_info")
+    expect(app_update_info["name"]).to eq(app.name)
+    expect(app_update_info["maintenance"]).to be_truthy
   end
 
   it "error with bad app" do

--- a/spec/unit/reaper_spec.rb
+++ b/spec/unit/reaper_spec.rb
@@ -122,18 +122,18 @@ describe "Reaper" do
   describe "reaper throttle" do
     it "increments and decrements based on min_sleep" do
       reaper_throttle = Hatchet::Reaper::ReaperThrottle.new(initial_sleep: 2)
-      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+      reaper_throttle.call(max_sleep: 5) do |sleep_for|
         expect(sleep_for).to eq(2)
       end
-      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+      reaper_throttle.call(max_sleep: 5) do |sleep_for|
         expect(sleep_for).to eq(4)
       end
-      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+      reaper_throttle.call(max_sleep: 5) do |sleep_for|
         expect(sleep_for).to eq(5)
       end
       # The throttle is now reset since it hit the min_sleep value
 
-      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+      reaper_throttle.call(max_sleep: 5) do |sleep_for|
         expect(sleep_for).to eq(2)
       end
     end

--- a/spec/unit/reaper_spec.rb
+++ b/spec/unit/reaper_spec.rb
@@ -1,0 +1,152 @@
+require "spec_helper"
+
+describe "Reaper" do
+  describe "cycle" do
+    it "does not delete anything if under the limit" do
+      reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 1, io: StringIO.new)
+
+      def reaper.get_heroku_apps
+        @called_get_heroku_apps = true
+
+        @mock_apps ||= [{"name" => "hatchet-t-foo", "id" => 1, "maintenance" => true, "created_at" => Time.now.to_s}]
+      end
+      def reaper.check_get_heroku_apps_called; @called_get_heroku_apps ; end
+      def reaper.reap_once; raise "should not be called"; end
+
+      reaper.cycle
+
+      expect(reaper.check_get_heroku_apps_called).to be_truthy
+    end
+
+    it "deletes a maintenance mode app on error" do
+      reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 1, io: StringIO.new)
+
+      def reaper.get_heroku_apps
+        @mock_apps ||= [
+          {"name" => "hatchet-t-unfinished", "id" => 2, "maintenance" => false, "created_at" => Time.now.to_s},
+          {"name" => "hatchet-t-foo", "id" => 1, "maintenance" => true, "created_at" => Time.now.to_s}
+        ]
+      end
+      def reaper.destroy_with_log(name: , id: )
+        @reaper_destroy_called_with = {"name" => name, "id" => id}
+      end
+      def reaper.destroy_called_with; @reaper_destroy_called_with; end
+
+      reaper.cycle(app_exception_message: true)
+
+      expect(reaper.destroy_called_with).to eq({"name" => "hatchet-t-foo", "id" => 1})
+    end
+
+    it "deletes maintenance mode app when over limit" do
+      reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 0, io: StringIO.new)
+
+      def reaper.get_heroku_apps
+        @mock_apps ||= [{"name" => "hatchet-t-foo", "id" => 1, "maintenance" => true, "created_at" => Time.now.to_s}]
+      end
+      def reaper.destroy_with_log(name: , id: )
+        @reaper_destroy_called_with = {"name" => name, "id" => id}
+      end
+      def reaper.destroy_called_with; @reaper_destroy_called_with; end
+
+      reaper.cycle
+
+      expect(reaper.destroy_called_with).to eq({"name" => "hatchet-t-foo", "id" => 1})
+    end
+
+    it "deletes an old app that is past TLL" do
+      reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 0, io: StringIO.new)
+
+      def reaper.get_heroku_apps
+        two_days_ago = DateTime.now.new_offset(0) - 2
+        @mock_apps ||= [{"name" => "hatchet-t-foo", "id" => 1, "maintenance" => false, "created_at" => two_days_ago.to_s }]
+      end
+      def reaper.destroy_with_log(name: , id: )
+        @reaper_destroy_called_with = {"name" => name, "id" => id}
+      end
+      def reaper.destroy_called_with; @reaper_destroy_called_with; end
+
+      reaper.cycle
+
+      expect(reaper.destroy_called_with).to eq({"name" => "hatchet-t-foo", "id" => 1})
+    end
+
+    it "sleeps, refreshes app list, and tries again when an old app is not past TTL" do
+      warning = StringIO.new
+      reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 1, initial_sleep: 0, io: warning)
+
+      def reaper.get_heroku_apps
+        now = DateTime.now.new_offset(0)
+        @mock_apps ||= [{"name" => "hatchet-t-foo", "id" => 1, "maintenance" => false, "created_at" => now.to_s }]
+      end
+      def reaper.destroy_with_log(name: , id: )
+        @reaper_destroy_called_with = {"name" => name, "id" => id}
+      end
+      def reaper.destroy_called_with; @reaper_destroy_called_with; end
+      def reaper.sleep(val)
+        @_slept_for = val
+      end
+
+      def reaper.get_slept_for_val; @_slept_for; end
+
+      reaper.cycle(app_exception_message: true)
+
+      expect(reaper.get_slept_for_val).to eq(0)
+      expect(reaper.destroy_called_with).to eq(nil)
+
+      expect(warning.string).to match("WARNING")
+      expect(warning.string).to match("total_app_count: 1, hatchet_app_count: 1/#{Hatchet::Reaper::HATCHET_APP_LIMIT}, finished: 0, unfinished: 1")
+    end
+  end
+
+  describe "app age" do
+    it "calculates young apps" do
+      time_now = DateTime.parse("2020-07-28T14:40:00Z")
+      age = Hatchet::Reaper::AppAge.new(created_at: time_now, time_now: time_now, ttl_minutes: 1)
+      expect(age.in_minutes).to eq(0.0)
+      expect(age.too_young_to_die?).to be_truthy
+      expect(age.can_delete?).to be_falsey
+      expect(age.sleep_for_ttl).to eq(60)
+    end
+
+    it "calculates old apps" do
+      time_now = DateTime.parse("2020-07-28T14:40:00Z")
+      created_at = time_now - 2
+      age = Hatchet::Reaper::AppAge.new(created_at: created_at, time_now: time_now, ttl_minutes: 1)
+      expect(age.in_minutes).to eq(2880.0)
+      expect(age.too_young_to_die?).to be_falsey
+      expect(age.can_delete?).to be_truthy
+      expect(age.sleep_for_ttl).to eq(0)
+    end
+  end
+
+  describe "reaper throttle" do
+    it "increments and decrements based on min_sleep" do
+      reaper_throttle = Hatchet::Reaper::ReaperThrottle.new(initial_sleep: 2)
+      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+        expect(sleep_for).to eq(2)
+      end
+      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+        expect(sleep_for).to eq(4)
+      end
+      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+        expect(sleep_for).to eq(5)
+      end
+      # The throttle is now reset since it hit the min_sleep value
+
+      reaper_throttle.call(min_sleep: 5) do |sleep_for|
+        expect(sleep_for).to eq(2)
+      end
+    end
+  end
+  it "over limit" do
+    reaper = Hatchet::Reaper.new(api_rate_limit: -> (){}, io: StringIO.new)
+    def reaper.hatchet_app_count; Hatchet::Reaper::HATCHET_APP_LIMIT + 1; end
+
+    expect(reaper.over_limit?).to be_truthy
+
+    reaper = Hatchet::Reaper.new(api_rate_limit: -> (){}, io: StringIO.new)
+    def reaper.hatchet_app_count; Hatchet::Reaper::HATCHET_APP_LIMIT - 1; end
+
+    expect(reaper.over_limit?).to be_falsey
+  end
+end

--- a/spec/unit/reaper_spec.rb
+++ b/spec/unit/reaper_spec.rb
@@ -138,6 +138,7 @@ describe "Reaper" do
       end
     end
   end
+
   it "over limit" do
     reaper = Hatchet::Reaper.new(api_rate_limit: -> (){}, io: StringIO.new)
     def reaper.hatchet_app_count; Hatchet::Reaper::HATCHET_APP_LIMIT + 1; end


### PR DESCRIPTION
## Fix Global Heroku app Limits

Issue: https://github.com/heroku/hatchet/issues/90

When the reaper was originally introduced there was a limit of 100 apps per Heroku account. As of today my account has 224 apps, because it is connected to multiple organizations. This means when I run with my local account, every time `reaper.cycle` is called it deletes a hatchet app even though it doesn't need to.

The "fix" for this is to remove the HEROKU_APP_LIMIT setting and instead trying to detect when we've been going over the limit.

This was accomplished by forcing the reaper to reap once when an exception is raised in the creation of an app. (Note reaping does not guarantee deletion of an app if none are "finished" or old enough). It can also trigger the issue with "minimum time to live" listed below if a parallel run was attempted locally.

## Fix Minimum time to live

Issue: https://github.com/heroku/hatchet/issues/89

The problem looks like this, in a deploy during a test on test run on CI will end up deleting an app currently being deployed, this ends up generating an error like this:

```
remote: !  No such app as hatchet-t-522c335bea.
```

The most common reason this happens is that there are more hatchet apps attempting to be deployed than are configured for the limit. For example:

- A test suite can concurrently run 20 tests and has a HATCHET_APP_LIMIT=80. Each test run on CI executes the same tests against 3 stacks meaning each CI run executes 60 app deploys concurrently
  - If two test runs are executing concurrently the required number of apps is 2x 60 which is 120 which is over the limit of 80. When this happens a reaper will likely destroy an app as it is in progress.
  - Keep in mind when merging tests to master, the suite may be re-run, or when pushing to two different branches. If multiple engineers are working on PRs at the same time this can also happen...

This problem is especially bad given the distributed nature of our tests, and given that tests have built in retries. It ends up really straining the system and taking a long time to exit if the developer doesn't notice and manually kill one of the extra test runs. 

This problem also means that the developer needs to always know the maximum number of concurrent apps that are likely to be deployed at a time against a given API key. This is extremely difficult to do in a distributed setting as illustrated above.

The solution proposed in #89 is to introduce a minimum "time to live" for apps. The idea is that all tests should be able to finish within this window. If we guarantee that all apps live for at least that long, then even if we accidentally go over our assigned limits, then the system will slow down instead of failing.

Originally implemented in https://github.com/heroku/hatchet/pull/84 it was later reverted. The behavior is not great since most tests exit very quickly around 1-3 minutes. Forcing ALL apps to live for a minimum of 7 minutes effectively meant that a single CI run could not take fewer than seven minutes (if it's close to using the HATCHET_APP_LIMIT on each CI run). When merged in, it effectively took a CI run on master to execute for about 15+ minutes which was not acceptable.

## Fix Minimum time to live + "finished" (maintenance=true) tracking

The solution to the "time to live" problem of increased test time is to find a more granular way to track when an app can be safely destroyed. While we still want to have a minimum time to live for apps currently being tested, the API call that returns our list of app info also returns some metadata status including whether or not the app is in maintenance mode.

The solution then means when an app is done (App#teardown! is called) then an API call will be made to set it to maintenance mode. This will communicate to the reaper it can be cleaned immediately and it does not have to wait for seven minutes.

This creates a two queue system with a fast "finished" queue of apps that can be deleted right away, and a slower "unfinished" queue. The unfinished queue will only be checked after the finished queue is drained. When we try to delete an "unifinished" app we first check to see how long it's been alive. If it's older than the TTL then we can remove it right away. Otherwise the system will throttle itself gradually to give the system a chance to "finish" some apps. It will check again in 10s, 20s, 40s, 80s, ... until it hits the minimum time to live for the oldest "unfinished" app at which time it will then reset.

## Extra debugging info for the reaper

All outputs from the reaper now include extra debugging information about the status of the system. Previously these values were being logged inconsistently making some of the above bugs harder to reason about.