### PR TITLE
Rate throttle `git push heroku master`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
 - Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)
 
 ## 6.0.0

--- a/lib/hatchet/api_rate_limit.rb
+++ b/lib/hatchet/api_rate_limit.rb
@@ -1,14 +1,11 @@
-# Wraps platform-api and adds API rate limits
+# Legacy class
 #
-# Instead of:
+# Not needed since rate throttling went directly into the platform-api gem.
+# This class is effectively now a no-op
 #
-#     platform_api.pipeline.create(name: @name)
-#
-# Use:
-#
-#     api_rate_limit = ApiRateLimit.new(platform_api)
-#     api_rate_limit.call.pipeline.create(name: @name)
-#
+# It's being left in as it's interface was public and it's hard-ish to
+# deprecate/remove. Since it's so small there's not much value in removal
+# so it's probably fine to keep around for quite some time.
 class ApiRateLimit
   def initialize(platform_api)
     @platform_api = platform_api
@@ -16,14 +13,6 @@ class ApiRateLimit
     @called   = 0
   end
 
-
-  # Sleeps for progressively longer when api rate limit capacity
-  # is lower.
-  #
-  # Unfortunatley `@platform_api.rate_limit` is an extra API
-  # call, so by checking our limit, we also are using our limit 😬
-  # to partially mitigate this, only check capacity every 5
-  # api calls, or if the current capacity is under 1000
   def call
     # @called += 1
 

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -14,9 +14,13 @@ module Hatchet
     class FailedDeploy < StandardError; end
 
     class FailedDeployError < FailedDeploy
-      def initialize(app, output)
+      attr_reader :output
+
+      def initialize(app, message, output: )
+        @output = output
         msg = "Could not deploy '#{app.name}' (#{app.repo_name}) using '#{app.class}' at path: '#{app.directory}'\n"
         msg << "if this was expected add `allow_failure: true` to your deploy hash.\n"
+        msg << "#{message}\n"
         msg << "output:\n"
         msg << "#{output}"
         super(msg)
@@ -24,9 +28,13 @@ module Hatchet
     end
 
     class FailedReleaseError < FailedDeploy
-      def initialize(app, output)
+      attr_reader :output
+
+      def initialize(app, message, output: )
+        @output = output
         msg = "Could not release '#{app.name}' (#{app.repo_name}) using '#{app.class}' at path: '#{app.directory}'\n"
         msg << "if this was expected add `allow_failure: true` to your deploy hash.\n"
+        msg << "#{message}\n"
         msg << "output:\n"
         msg << "#{output}"
         super(msg)

--- a/lib/hatchet/git_app.rb
+++ b/lib/hatchet/git_app.rb
@@ -5,16 +5,57 @@ module Hatchet
       "https://git.heroku.com/#{name}.git"
     end
 
+    # Helper class to be used along with the PlatformAPI.rate_throttle interface
+    # that expects a response object
+    class FakeResponse
+      attr_reader :status, :headers
+
+      def initialize(status:, remaining: )
+        @status = status
+
+        @headers = {
+          "RateLimit-Remaining" => remaining,
+          "RateLimit-Multiplier" => 1,
+          "Content-Type" => "text/plain".freeze
+        }
+      end
+    end
+
     def push_without_retry!
+      output = ""
+
+      # The `git push heroku` call can fail due to a rate limit, instead of re-writing our own rate throttling
+      # we can hijack the existing Platform API rate throttling mechanism by providing it with a fake response
+      PlatformAPI.rate_throttle.call do
+        remaining = @platform_api.rate_limit.info["remaining"]
+        output = git_push_heroku_yall
+        FakeResponse.new(status: 200, remaining: remaining)
+      rescue FailedDeploy => e
+        if e.output.match?(/reached the API rate limit/)
+          FakeResponse.new(status: 429, remaining: remaining)
+        elsif @allow_failure
+          output = e.output
+          FakeResponse.new(status: 200, remaining: remaining)
+        else
+          raise e
+        end
+      end
+
+      return output
+    end
+
+    private def git_push_heroku_yall
       output = `git push #{git_repo} master 2>&1`
+
       if !$?.success?
-        raise FailedDeployError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}\n#{output}") unless @allow_failure
+        raise FailedDeployError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}", output: output)
       end
 
       releases = platform_api.release.list(name)
       if releases.last["status"] == "failed"
-        raise FailedReleaseError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}\n#{output}") unless @allow_failure
+        raise FailedReleaseError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}", output: output)
       end
+
       return output
     end
   end

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -1,6 +1,26 @@
 require("spec_helper")
 
 describe "AppTest" do
+  it "rate throttles `git push` " do
+    app = Hatchet::GitApp.new("default_ruby")
+    def app.git_push_heroku_yall
+      @_git_push_heroku_yall_call_count ||= 0
+      @_git_push_heroku_yall_call_count += 1
+      if @_git_push_heroku_yall_call_count >= 2
+        "Success"
+      else
+        raise Hatchet::App::FailedDeployError.new(self, "message", output: "Your account reached the API rate limit Please wait a few minutes before making new requests")
+      end
+    end
+
+    def app.sleep_called?; @sleep_called; end
+
+    def app.what_is_git_push_heroku_yall_call_count; @_git_push_heroku_yall_call_count; end
+    app.push_without_retry!
+
+    expect(app.what_is_git_push_heroku_yall_call_count).to be(2)
+  end
+
   it "app with default" do
     app = Hatchet::App.new("default_ruby", buildpacks: [:default])
     expect(app.buildpacks.first).to match("https://github.com/heroku/heroku-buildpack-ruby")


### PR DESCRIPTION
When an app is attempted to be deployed it can fail due to an API rate limit like this:

```
     Hatchet::App::FailedDeployError:
       Could not deploy 'hatchet-t-3ae0c484c6' (rails5_ruby_schema_format) using 'Hatchet::GitApp' at path: 'repo_fixtures/repos/ci/rails5_ruby_schema_format'
       if this was expected add `allow_failure: true` to your deploy hash.
       output:
       Buildpack: nil
       Repo: https://git.heroku.com/hatchet-t-3ae0c484c6.git
       remote: Compressing source files... done.        
       remote: Building source:        
       remote: 
       remote: !    Your account reached the API rate limit Please wait a few minutes before making new requests        
       remote: 
       To https://git.heroku.com/hatchet-t-3ae0c484c6.git
        ! [remote rejected] master -> master (pre-receive hook declined)
       error: failed to push some refs to 'https://git.heroku.com/hatchet-t-3ae0c484c6.git'
```

This can happen at both the initial deploy and at the release phase. Currently this rate limit case is unhandled. We are using the general/generic retry mechanism of hatchet to account for this case.

This is not great as the retry behavior has no sleep/backoff behavior and will quickly hit the limit again. Also it only retries if the app failed to deploy, if the `allow_failure` flag is set it will not be retried but any assertions on the output will fail since the app never actually deployed. 

This PR proposes that we hook into the existing PlatformAPI rate limits. This is also done manually at https://github.com/heroku/hatchet/blob/a8d2c2f0a6a387c70981c1429c24b197baa6c9f9/lib/hatchet/test_run.rb#L184-L189.

The only difference is that the `PlatfromAPI.rate_throttle` interface expects a response object that includes a `status` that returns an integer and `headers` that returns a hash. We can re-use this logic by generating our own `FakeResponse` object. In the case where the output matches "reached the API rate limit" then we will tell the rate throttle to sleep and try again (by using  429 response code). When it succeeds, we will tell it we got a successful response (200 status code).

This logic will prevent a failure from rate limiting while `git push heroku master` is being called. Since the rate throttling rate is tuned as the process is running (the sleep value is remembered and adjusted) by using the same rate throttle mechanism here a rate throttle will inform the rest of our system.