### PR TITLE
Throttle `heroku run` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)
 - App#deploy without a block will no longer run `teardown!` automatically (https://github.com/heroku/hatchet/pull/97)
 - Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
+- Calls to `app.run` are now rate throttled (https://github.com/heroku/hatchet/pull/99)
 - Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)
 
 ## 6.0.0

--- a/lib/hatchet/shell_throttle.rb
+++ b/lib/hatchet/shell_throttle.rb
@@ -1,0 +1,71 @@
+module Hatchet
+  # A class for throttling non-http resources
+  #
+  # Non-http calls can be rate-limited for example shell calls to `heroku run ` and `git push heroku`
+  # this class provides an easy interface to leverage the rate throttling behavior baked into `PlatformAPI`
+  # for calls things that do not have a real associated web request
+  #
+  # Example:
+  #
+  #   output = ""
+  #   ShellThrottle.new(platform_api: @platform_api).call
+  #     output = `git push heroku main`
+  #     throw(:throttle) if output.match?(/reached the API rate limit/)
+  #   end
+  #   puts output
+  #
+  # In this example `git push heroku main` will retry and backoff until the output no longer matches `reached the API rate limit`.
+  #
+  class ShellThrottle
+    def initialize(platform_api: )
+      @platform_api = platform_api
+    end
+
+    def call
+      out = nil
+      PlatformAPI.rate_throttle.call do
+        catch(:throttle) do
+          out = yield
+          return
+        end
+
+        try_again
+      end
+      return out
+    end
+
+    private def success
+      FakeResponse.new(status: 200, remaining: remaining)
+    end
+
+    private def try_again
+      FakeResponse.new(status: 429, remaining: remaining)
+    end
+
+    private def remaining
+      @platform_api.rate_limit.info["remaining"]
+    end
+
+
+    # Helper class to be used along with the PlatformAPI.rate_throttle interface
+    # that expects a response object
+    #
+    # Example:
+    #
+    #   FakeResponse.new(status: 200, remaining: 2).status #=> 200
+    #   FakeResponse.new(status: 200, remaining: 2).headers["RateLimit-Remaining"] #=> 2
+    class FakeResponse
+      attr_reader :status, :headers
+
+      def initialize(status:, remaining: )
+        @status = status
+
+        @headers = {
+          "RateLimit-Remaining" => remaining,
+          "RateLimit-Multiplier" => 1,
+          "Content-Type" => "text/plain".freeze
+        }
+      end
+    end
+  end
+end

--- a/spec/unit/shell_throttle.rb
+++ b/spec/unit/shell_throttle.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe "ShellThrottle" do
+  it "throttles when throw is called" do
+    platform_api = Hatchet::Runner.new("default_ruby").platform_api
+
+    @count = 0
+    Hatchet::ShellThrottle.new(platform_api: platform_api).call do
+      @count += 1
+      if @count >= 2
+        # No throttle
+      else
+        throw(:throttle)
+      end
+    end
+    expect(@count).to eq(2)
+  end
+
+  it "does not throttle when throw is NOT called" do
+    platform_api = Hatchet::Runner.new("default_ruby").platform_api
+
+    @count = 0
+    Hatchet::ShellThrottle.new(platform_api: platform_api).call do
+      @count += 1
+    end
+    expect(@count).to eq(1)
+  end
+end


### PR DESCRIPTION
Building off of https://github.com/heroku/hatchet/pull/98 we now also throttle calls to `heroku run`.