### PR TITLE
Ignore 403 on App delete, Log request ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Ignore  403 on app delete due to race condition (https://github.com/heroku/hatchet/pull/101)
 - Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps ()
 - Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
 - Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -166,19 +166,19 @@ module Hatchet
       @api_rate_limit.call.app.delete(id)
 
       io.puts message
-
     rescue Excon::Error::NotFound => e
       body = e.response.body
+      request_id = e.response.headers["Request-Id"]
       if body =~ /Couldn\'t find that app./
-        io.puts "Duplicate destoy attempted #{name.inspect}: #{id}"
+        io.puts "Duplicate destoy attempted #{name.inspect}: #{id}, status: 404, request_id: #{request_id}"
         raise AlreadyDeletedError.new
       else
         raise e
       end
     rescue Excon::Error::Forbidden => e
-      puts "403 random error debugging: " + message
-      puts e.methods
-      raise e
+      request_id = e.response.headers["Request-Id"]
+      io.puts "Duplicate destoy attempted #{name.inspect}: #{id}, status: 403, request_id: #{request_id}"
+      raise AlreadyDeletedError.new
     end
 
     private def hatchet_app_count


### PR DESCRIPTION
- When an app is deleted too quickly then it might come back as a 403. 
- When that happens log the request ID for future debugging if needed.