### PR TITLE
Remove support for passing a block to App#run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Remove deprecated support for passing a block to `App#run` (https://github.com/heroku/hatchet/pull/105)
 - Ignore  403 on app delete due to race condition (https://github.com/heroku/hatchet/pull/101)
 - The hatchet.lock file can now be locked to "main" in addition to "master" (https://github.com/heroku/hatchet/pull/86)
 - Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps ()

--- a/hatchet.gemspec
+++ b/hatchet.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency "activesupport", "~> 6"
   gem.add_dependency "platform-api",  "~> 3"
   gem.add_dependency "rrrretry",      "~> 1"
   gem.add_dependency "excon",         "~> 0"
   gem.add_dependency "thor",          "~> 0"
-  gem.add_dependency "repl_runner",   "~> 0.0.3"
   gem.add_dependency "threaded",      "~> 0"
 
   gem.add_development_dependency "rspec"

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -158,12 +158,6 @@ module Hatchet
       heroku_command = build_heroku_command(command, options)
 
       allow_run_multi! if @run_multi
-      if block_given?
-        STDERR.puts "Using App#run with a block is deprecated, support for ReplRunner is being removed.\n#{caller}"
-        # When we deprecated this we can get rid of the "cmd_type" from the method signature
-        require 'repl_runner'
-        return ReplRunner.new(cmd_type, heroku_command, options).run(&block)
-      end
 
       output = ""
 


### PR DESCRIPTION
Since it's been deprecated as of Hatchet 5.0.0, and removing support means we can drop the dependency on `repl_runner`, and so one of the consumers of `activesupport`.

The addition of `activesupport` to Hatchet's gemspec is required since Hatchet itself relies upon `activesupport` but was previously relying on it being pulled in implicitly via `repl_runner`. Later PRs will remove the dependency on `activesupport` entirely.

This is a breaking change, so will require a bump to Hatchet 7.0.0. However the next part of #103 will also be a breaking change (dropping support for `blank?` / removing the dependency on `activesupport`), so please don't release 7.0.0 until the next PR also lands. We also may want to release the current changes on `main` as a 6.x release, in which case I'll rebase this PR on top of that, once released.

Fixes first half of #103.