### PR TITLE
Fixes to `hatchet lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD
 
+- Bugfix: Allow `hatchet lock` to be run against new projects (https://github.com/heroku/hatchet/pull/118)
+- Bugfix: Allow `hatchet.lock` file to lock a repo to a different branch than what is specified as default for GitHub (https://github.com/heroku/hatchet/pull/118)
+
 ## 7.0.0
 
 - ActiveSupport's Object#blank? and Object#present? are no longer provided by default (https://github.com/heroku/hatchet/pull/107)

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -67,7 +67,7 @@ class HatchetCLI < Thor
   desc "locks to specific git commits", "updates hatchet.lock"
   def lock
     lock_hash = {}
-    lockfile_hash = load_lockfile
+    lockfile_hash = load_lockfile(create_if_does_not_exist: true)
     dirs.map do |directory, git_repo|
       Threaded.later do
         puts "== locking #{directory}"
@@ -118,10 +118,15 @@ class HatchetCLI < Thor
   end
 
   private
-  def load_lockfile
+  def load_lockfile(create_if_does_not_exist: false)
     return YAML.safe_load(File.read('hatchet.lock')).to_h
   rescue Errno::ENOENT
-    raise "No such file found `hatchet.lock` please run `$ bundle exec hatchet lock`"
+    if create_if_does_not_exist
+      FileUtils.touch('hatchet.lock')
+      {}
+    else
+      raise "No such file found `hatchet.lock` please run `$ bundle exec hatchet lock`"
+    end
   end
 
   def bad_repo?(url)

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -156,7 +156,7 @@ class HatchetCLI < Thor
   end
 
   def checkout_commit(directory, commit)
-    cmd("cd #{directory} && git reset --hard #{commit}")
+    cmd("cd #{directory} && git fetch origin #{commit} && git checkout #{commit} && git checkout - && git reset --hard #{commit}")
   end
 
   def commit_at_directory(directory)

--- a/spec/hatchet/lock_spec.rb
+++ b/spec/hatchet/lock_spec.rb
@@ -28,3 +28,23 @@ describe "LockTest" do
     expect(branch).to eq("main")
   end
 end
+
+describe "isolated lock tests" do
+  it "works when there's no hatchet.lock" do
+    Dir.mktmpdir do |dir|
+      dir = Pathname.new(dir)
+
+      dir.join("hatchet.json").open("w+") do |f|
+        f.puts %Q{{ "foo": ["sharpstone/lock_fail_main_default_is_master"] }}
+      end
+
+      output = `cd #{dir} && hatchet lock 2>&1`
+
+      raise "Expected cmd `hatchet lock` to succeed, but it did not: #{output}" unless $?.success?
+      expect(output).to include("locking")
+
+      lockfile_contents = dir.join('hatchet.lock').read
+      expect(lockfile_contents).to include("repos/foo/lock_fail_main_default_is_master")
+    end
+  end
+end


### PR DESCRIPTION
- Allow `hatchet lock` to be called on a new app
- Allow `hatchet.lock` to specify a different branch than what github currently has as the default