### PR TITLE
[close #109] Allow retrying failed release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD
 
+- Initializing an `App` can now take a `retries` key to overload the global hatchet env var (https://github.com/heroku/hatchet/pull/119)
+- Calling `App#commit!` now adds an empty commit if there is no changes on disk (https://github.com/heroku/hatchet/pull/119)
+- Bugfix: Failed release phase in deploys can now be re-run (https://github.com/heroku/hatchet/pull/119)
 - Bugfix: Allow `hatchet lock` to be run against new projects (https://github.com/heroku/hatchet/pull/118)
 - Bugfix: Allow `hatchet.lock` file to lock a repo to a different branch than what is specified as default for GitHub (https://github.com/heroku/hatchet/pull/118)
 

--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ WARNING: Enabling `run_multi` setting on an app will charge your Heroku account 
 WARNING: Do not use `run_multi` if you're not using the `deploy` block syntax or manually call `teardown!` inside the text context [more info about how behavior does not work with the `after` block syntax in rspec](https://github.com/heroku/hatchet/issues/110).
 WARNING: To work, `run_multi` requires your application to have a `web` process associated with it.
 
+- `retries` (Integer): When passed in, this value will be used insead of the global `HATCHET_RETRIES` set via environment variable. When `allow_failures: true` is set as well as a retries value, then the application will not retry pushing to Heroku.
+
 ### App methods:
 
 - `app.set_config()`: Updates the configuration on your app taking in a hash

--- a/lib/hatchet/git_app.rb
+++ b/lib/hatchet/git_app.rb
@@ -33,6 +33,7 @@ module Hatchet
 
       releases = platform_api.release.list(name)
       if releases.last["status"] == "failed"
+        commit! # An empty commit allows us to deploy again
         raise FailedReleaseError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}", output: output)
       end
 

--- a/spec/hatchet/allow_failure_git_spec.rb
+++ b/spec/hatchet/allow_failure_git_spec.rb
@@ -13,17 +13,29 @@ describe "AllowFailureGitTest" do
     }
 
     it "is marked as a failure if the release fails" do
+      app = Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc, retries: 2)
+      def app.retry_error_message(*args); @test_attempts_count ||= 0; @test_attempts_count += 1; "" end
+      def app.test_attempts_count; @test_attempts_count ; end
+
       expect {
-        Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc, retries: 2).deploy {}
+        app.deploy {}
       }.to raise_error { |error|
         expect(error).to be_a(Hatchet::App::FailedReleaseError)
         expect(error.message).to_not match("Everything up-to-date")
       }
+
+      expect(app.test_attempts_count).to eq(2)
     end
 
     it "works when failure is allowed" do
-      Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc, allow_failure: true).deploy do |app|
-        expect(app.output).to match("failing on release")
+      Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc, allow_failure: true, retries: 3).tap do |app|
+        def app.retry_error_message(*args); @test_attempts_count ||= 0; @test_attempts_count += 1; "" end
+        def app.test_attempts_count; @test_attempts_count ; end
+
+        app.deploy do
+          expect(app.output).to match("failing on release")
+          expect(app.test_attempts_count).to eq(nil)
+        end
       end
     end
   end

--- a/spec/hatchet/allow_failure_git_spec.rb
+++ b/spec/hatchet/allow_failure_git_spec.rb
@@ -14,8 +14,11 @@ describe "AllowFailureGitTest" do
 
     it "is marked as a failure if the release fails" do
       expect {
-        Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc).deploy {}
-      }.to(raise_error(Hatchet::App::FailedReleaseError))
+        Hatchet::GitApp.new("default_ruby", before_deploy: release_fail_proc, retries: 2).deploy {}
+      }.to raise_error { |error|
+        expect(error).to be_a(Hatchet::App::FailedReleaseError)
+        expect(error.message).to_not match("Everything up-to-date")
+      }
     end
 
     it "works when failure is allowed" do


### PR DESCRIPTION
When a deploy succeeds but the release fails the git remote retains the contents of the `git push`. This means if you immediately try to push again that you'll get a `Everything up-to-date` from the remote and Heroku will not try to re-build your project.

We don't want that behavior, we want to retry on a failed release incase it's intermittent. This PR adds an empty commit when a failed release is detected.