### PR TITLE
Fix destroy all functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 7.1.1
+
+- Fix destroy_all functionality (https://github.com/heroku/hatchet/pull/121)
+
 ## 7.1.0
 
 - Initializing an `App` can now take a `retries` key to overload the global hatchet env var (https://github.com/heroku/hatchet/pull/119)

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -80,7 +80,7 @@ module Hatchet
 
     # No guardrails, will delete all apps that match the hatchet namespace
     def destroy_all
-      get_apps
+      refresh_app_list
 
       (@finished_hatchet_apps + @unfinished_hatchet_apps).each do |app|
         begin

--- a/spec/unit/reaper_spec.rb
+++ b/spec/unit/reaper_spec.rb
@@ -1,6 +1,22 @@
 require "spec_helper"
 
 describe "Reaper" do
+  it "destroy all" do
+    reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 1, io: StringIO.new)
+
+    def reaper.get_heroku_apps
+      @mock_apps ||= [
+        {"name" => "hatchet-t-unfinished", "id" => 2, "maintenance" => false, "created_at" => Time.now.to_s},
+        {"name" => "hatchet-t-foo", "id" => 1, "maintenance" => true, "created_at" => Time.now.to_s}
+      ]
+    end
+    def reaper.destroy_with_log(*args); @destroy_with_log_count ||= 0; @destroy_with_log_count += 1; end
+
+    reaper.destroy_all
+
+    expect(reaper.instance_variable_get("@destroy_with_log_count")).to eq(1)
+  end
+
   describe "cycle" do
     it "does not delete anything if under the limit" do
       reaper = Hatchet::Reaper.new(api_rate_limit: Object.new, hatchet_app_limit: 1, io: StringIO.new)


### PR DESCRIPTION
```
$ bundle exec hatchet destroy --all
home/travis/.rvm/gems/ruby-2.5.3/gems/heroku_hatchet-7.1.0/lib/hatchet/reaper.rb:83:in `destroy_all': undefined local variable or method `get_apps' for #<Hatchet::Reaper:0x000000000317f400> (NameError)
from /home/travis/.rvm/gems/ruby-2.5.3/gems/heroku_hatchet-7.1.0/bin/hatchet:112:in `destroy'
from /home/travis/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
from /home/travis/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
from /home/travis/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
from /home/travis/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
from /home/travis/.rvm/gems/ruby-2.5.3/gems/heroku_hatchet-7.1.0/bin/hatchet:186:in `<top (required)>'
from /home/travis/.rvm/gems/ruby-2.5.3/bin/hatchet:23:in `load'
from /home/travis/.rvm/gems/ruby-2.5.3/bin/hatchet:23:in `<main>'
from /home/travis/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
from /home/travis/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
```