### PR TITLE
Fix support for deploying `main` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix support for Hatchet deploying the 'main' branch (https://github.com/heroku/hatchet/pull/122)
+
 ## 7.1.1
 
 - Fix destroy_all functionality (https://github.com/heroku/hatchet/pull/121)

--- a/lib/hatchet/git_app.rb
+++ b/lib/hatchet/git_app.rb
@@ -25,7 +25,7 @@ module Hatchet
     end
 
     private def git_push_heroku_yall
-      output = `git push #{git_repo} master 2>&1`
+      output = `git push #{git_repo} HEAD:main 2>&1`
 
       if !$?.success?
         raise FailedDeployError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}", output: output)

--- a/spec/hatchet/git_spec.rb
+++ b/spec/hatchet/git_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe "GitAppTest" do
-  it "can deploy git app" do
-    Hatchet::GitApp.new("rails5_ruby_schema_format").deploy do |app|
-      expect(app.run("ruby -v")).to match("2.6.6")
+  it "can deploy git app to the main branch" do
+    Hatchet::GitApp.new("lock_fail_main", allow_failure: true).deploy do |app|
+      expect(app.output).to match("INTENTIONAL ERROR")
     end
   end
 end


### PR DESCRIPTION
When I shipped support for the main branch I only checked that the lock file correctly installed the main branch, but never checked it could be deployed. 

In our deploy we previously ran `git push heroku master` which is short for `git push master:master` and this fails since there's no master branch of that repo. This force deploys HEAD instead.