### PR TITLE
Fix branch detection on CircleCI 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Important!! Fix branch name detection on CircleCI (https://github.com/heroku/hatchet/pull/124)
+
 ## 7.1.2
 
 - Fix support for Hatchet deploying the 'main' branch (https://github.com/heroku/hatchet/pull/122)

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -30,7 +30,7 @@ module Hatchet
     return ENV['TRAVIS_PULL_REQUEST_BRANCH'] if ENV['TRAVIS_PULL_REQUEST_BRANCH'] && !ENV['TRAVIS_PULL_REQUEST_BRANCH'].empty?
     return ENV['TRAVIS_BRANCH'] if ENV['TRAVIS_BRANCH']
 
-    out = `git describe --contains --all HEAD`.strip
+    out = `git rev-parse --abbrev-ref HEAD`.strip
     raise "Attempting to find current branch name. Error: Cannot describe git: #{out}" unless $?.success?
     out
   end

--- a/spec/hatchet/git_spec.rb
+++ b/spec/hatchet/git_spec.rb
@@ -6,4 +6,10 @@ describe "GitAppTest" do
       expect(app.output).to match("INTENTIONAL ERROR")
     end
   end
+
+  it "returns the correct branch name on circle CI" do
+    skip("only runs on circle") unless ENV["CIRCLE_BRANCH"]
+
+    expect(Hatchet.git_branch).to eq(ENV["CIRCLE_BRANCH"])
+  end
 end


### PR DESCRIPTION

We've been accidentally running all hatchet tests on CircleCI against `main`/`master` instead of the correct buildpack branch by accident.

https://twitter.com/schneems/status/1303785823263883264