### PR TITLE
Move disk modifying operations out of `setup!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- App#setup! no longer modifies files on disk. (https://github.com/heroku/hatchet/pull/125)
 - Add `$ hatchet init` command for bootstrapping new projects (https://github.com/heroku/hatchet/pull/123)
 
 ## 7.1.3

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -1,6 +1,28 @@
 require("spec_helper")
 
 describe "AppTest" do
+  it "does not modify local files by mistake" do
+    Dir.mktmpdir do |dir_1|
+      app = Hatchet::Runner.new(dir_1)
+      Dir.mktmpdir do |dir_2|
+        Dir.chdir(dir_2) do
+          FileUtils.touch("foo.txt")
+
+          app.setup!
+        end
+
+        entries_array = Dir.entries(dir_2)
+        entries_array -= ["..", ".", "foo.txt"]
+        expect(entries_array).to be_empty
+
+
+        entries_array = Dir.entries(dir_1)
+        entries_array -= ["..", ".", "foo.txt"]
+        expect(entries_array).to be_empty
+      end
+    end
+  end
+
   it "rate throttles `git push` " do
     app = Hatchet::GitApp.new("default_ruby")
     def app.git_push_heroku_yall

--- a/spec/hatchet/local_repo_spec.rb
+++ b/spec/hatchet/local_repo_spec.rb
@@ -13,14 +13,15 @@ describe "LocalRepoTest" do
 
   it "repos checked into git" do
     begin
-      app = Hatchet::App.new("repo_fixtures/different-folder-for-checked-in-repos/default_ruby")
-      app.in_directory do
-        expect(Dir.exist?(".git")).to eq(false)
-        app.setup!
-        expect(Dir.exist?(".git")).to eq(true)
+      fixture_dir = "repo_fixtures/different-folder-for-checked-in-repos/default_ruby"
+      app = Hatchet::App.new(fixture_dir)
+      def app.push_with_retry!; end
+
+      expect(Dir.exist?("#{fixture_dir}/.git")).to be_falsey
+
+      app.deploy do
+        expect(Dir.exist?(".git")).to be_truthy
       end
-    ensure
-      app.teardown! if app
     end
   end
 end


### PR DESCRIPTION
As described in https://github.com/heroku/heroku-buildpack-ruby/pull/1061 it's possible to accidentally modify disk when you didn't intend to using the `setup!` API. This PR fixes that by moving all the disk mutating calls to it's own method and ensuring it only gets called while in the directory.