### PR TITLE
[close #131] Retry App#run on empty results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Empty string returns from App#run now trigger retries (https://github.com/heroku/hatchet/pull/132)
 - Allow multiple `App#before_deploy` blocks to be set and called (https://github.com/heroku/hatchet/pull/126)
 - Deprecation: Calling `App#before_deploy` as a way to clear/replace the existing block should now be done with `App#before_deploy(:replace)` (https://github.com/heroku/hatchet/pull/126)
 - Rescue 403 on pipeline delete (https://github.com/heroku/hatchet/pull/130)

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -19,6 +19,7 @@ require 'hatchet/git_app'
 require 'hatchet/config'
 require 'hatchet/api_rate_limit'
 require 'hatchet/init_project'
+require 'hatchet/heroku_run'
 
 module Hatchet
   RETRIES = Integer(ENV['HATCHET_RETRIES']   || 1)

--- a/lib/hatchet/git_app.rb
+++ b/lib/hatchet/git_app.rb
@@ -23,6 +23,10 @@ module Hatchet
       return output
     end
 
+    def releases
+      platform_api.release.list(name)
+    end
+
     private def git_push_heroku_yall
       output = `git push #{git_repo} HEAD:main 2>&1`
 
@@ -30,7 +34,6 @@ module Hatchet
         raise FailedDeployError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}", output: output)
       end
 
-      releases = platform_api.release.list(name)
       if releases.last["status"] == "failed"
         commit! # An empty commit allows us to deploy again
         raise FailedReleaseError.new(self, "Buildpack: #{@buildpack.inspect}\nRepo: #{git_repo}", output: output)

--- a/lib/hatchet/heroku_run.rb
+++ b/lib/hatchet/heroku_run.rb
@@ -1,0 +1,96 @@
+module Hatchet
+  # Used for running Heroku commands
+  #
+  # Example:
+  #
+  #   run_obj = HerokuRun.new("ruby -v", app: app).call
+  #   puts run_obj.output #=> "ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]"
+  #   puts run_obj.status.success? #=> true
+  #
+  # There's a bug in specs sometimes where App#run will return an empty
+  # value. When that's detected then the command will be re-run. This can be
+  # optionally disabled by setting `retry_on_empty: false` if you're expecting
+  # the command to be empty.
+  #
+  class HerokuRun
+    attr_reader :command
+
+    def initialize(
+      command,
+      app: ,
+      heroku: {},
+      retry_on_empty: !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"],
+      raw: false,
+      stderr: $stderr)
+
+      @raw = raw
+      @app = app
+      @command = build_heroku_command(command, heroku || {})
+      @retry_on_empty = retry_on_empty
+      @stderr = stderr
+      @output = ""
+      @status = nil
+      @empty_fail_count = 0
+    end
+
+    def output
+      raise "You must run `call` on this object first" unless @status
+      @output
+    end
+
+    def status
+      raise "You must run `call` on this object first" unless @status
+      @status
+    end
+
+    def call
+      loop do
+        execute!
+
+        break unless output.empty?
+        break unless @retry_on_empty
+
+        @empty_fail_count += 1
+
+        break if @empty_fail_count >= 3
+
+        message = String.new("Empty output from command #{@command}, retrying the command.")
+        message << "\nTo disable pass in `retry_on_empty: false` or set HATCHET_DISABLE_EMPTY_RUN_RETRY=1 globally"
+        message << "\nfailed_count: #{@empty_fail_count}"
+        message << "\nreleases: #{@app.releases}"
+        message << "\n#{caller.join("\n")}"
+        @stderr.puts message
+      end
+
+      self
+    end
+
+    private def execute!
+      ShellThrottle.new(platform_api: @app.platform_api).call do |throttle|
+        run_shell!
+        throw(:throttle) if output.match?(/reached the API rate limit/)
+      end
+    end
+
+    private def run_shell!
+      @output = `#{@command}`
+      @status = $?
+    end
+
+    private def build_heroku_command(command, options = {})
+      command = command.shellescape unless @raw
+
+      default_options = { "app" => @app.name, "exit-code" => nil }
+      heroku_options_array = (default_options.merge(options)).map do |k,v|
+        # This was a bad interface decision
+        next if v == Hatchet::App::SkipDefaultOption # for forcefully removing e.g. --exit-code, a user can pass this
+
+        arg = "--#{k.to_s.shellescape}"
+        arg << "=#{v.to_s.shellescape}" unless v.nil? # nil means we include the option without an argument
+        arg
+      end
+
+      "heroku run #{heroku_options_array.compact.join(' ')} -- #{command}"
+    end
+  end
+end

--- a/spec/unit/heroku_run_spec.rb
+++ b/spec/unit/heroku_run_spec.rb
@@ -1,0 +1,115 @@
+require "spec_helper"
+
+describe "HerokuRun" do
+  def fake_app
+    app = Object.new
+    def app.name; "fake_app"; end
+    app
+  end
+
+  describe "options" do
+    it "escapes by default" do
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: fake_app)
+      expect(run_obj.command).to eq("heroku run --app=fake_app --exit-code -- ruby\\ -v")
+    end
+
+    it "escapes by default" do
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: fake_app, heroku: { "exit-code" => Hatchet::App::SkipDefaultOption })
+      expect(run_obj.command).to eq("heroku run --app=fake_app -- ruby\\ -v")
+    end
+
+    it "allows setting switch values by default" do
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: fake_app, heroku: { "no-tty" => nil })
+      expect(run_obj.command).to eq("heroku run --app=fake_app --exit-code --no-tty -- ruby\\ -v")
+    end
+
+    it "can be used to pass env vars" do
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: fake_app, heroku: { "env" => "HELLO=ohai;NAME=world" })
+      expect(run_obj.command).to eq("heroku run --app=fake_app --exit-code --env=HELLO\\=ohai\\;NAME\\=world -- ruby\\ -v")
+    end
+
+
+    it "lets me use raw values" do
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: fake_app, raw: true )
+      expect(run_obj.command).to eq("heroku run --app=fake_app --exit-code -- ruby -v")
+    end
+  end
+
+  describe "retry on empty" do
+    before(:all) do
+      @app = Hatchet::Runner.new("default_ruby")
+      @app.setup!
+    end
+
+    after(:all) do
+      @app.teardown!
+    end
+
+    it "retries 3 times on empty result" do
+      stderr = StringIO.new
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr)
+
+      def run_obj.run_shell!
+        @output = ""
+        @status = Object.new
+      end
+
+      run_obj.call
+
+      expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(3)
+      expect(stderr.string).to include("retrying the command.")
+    end
+
+    it "retries 0 times on NON empty result" do
+      stderr = StringIO.new
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr)
+
+      def run_obj.run_shell!
+        @output = "not empty"
+        @status = Object.new
+      end
+
+      run_obj.call
+
+      expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
+      expect(run_obj.output).to eq("not empty")
+    end
+
+    it "retries 0 times on empty result when disabled" do
+      stderr = StringIO.new
+      run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr, retry_on_empty: false)
+
+      def run_obj.run_shell!
+        @output = ""
+        @status = Object.new
+      end
+
+      run_obj.call
+
+      expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
+      expect(stderr.string).to_not include("retrying the command.")
+    end
+
+    it "retries 0 times on empty result when disabled via ENV var" do
+      begin
+        original_env = ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]
+        ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"] = "1"
+        stderr = StringIO.new
+        run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr)
+
+        def run_obj.run_shell!
+          @output = ""
+          @status = Object.new
+        end
+
+        run_obj.call
+
+        expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
+        expect(stderr.string).to_not include("retrying the command.")
+      ensure
+        ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"] = original_env
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
App#run (`heroku run`) commands sometimes return empty strings. We would love to know WHY so this pr does two things:

- Adds debugging information when this happens
- Retries the commands by default up to 3 times

I figure that it's unlikely someone will be running a `heroku run` session and expecting an empty result, unless that's how they detect some failure mode. If they are expecting it, then they can manually specify `retry_on_empty: false`.

For now the only extra debug info we're providing is the contents of releases. In the future we could enable `DEBUG="*"` by default and separately capture stdout versus stderr and output the full debug contents of stderr if needed.

In reality, the retry behavior here will likely be "good enough" to make this issue functionally disappear.

I extracted the behavior of running a `heroku run` command to it's own class to make unit testing easier and because app.rb is becoming a junk drawer of private methods.