### PR TITLE
[close #83] HATCHET_BUILDPACK_BASE updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Lazy evaluation of HATCHET_BUILDPACK_BASE env var (https://github.com/heroku/hatchet/pull/133)
+- Deprecating HATCHET_BUILDPACK_BASE default (https://github.com/heroku/hatchet/pull/133)
 - Allow multiple `App#before_deploy` blocks to be set and called (https://github.com/heroku/hatchet/pull/126)
 - Deprecation: Calling `App#before_deploy` as a way to clear/replace the existing block should now be done with `App#before_deploy(:replace)` (https://github.com/heroku/hatchet/pull/126)
 - Rescue 403 on pipeline delete (https://github.com/heroku/hatchet/pull/130)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -5,9 +5,13 @@ require 'tmpdir'
 
 module Hatchet
   class App
-    HATCHET_BUILDPACK_BASE   = (ENV['HATCHET_BUILDPACK_BASE'] || "https://github.com/heroku/heroku-buildpack-ruby.git")
+    HATCHET_BUILDPACK_BASE = -> {
+      ENV.fetch('HATCHET_BUILDPACK_BASE') {
+        warn "ENV HATCHET_BUILDPACK_BASE is not set. It currently defaults to the ruby buildpack. In the future this env var will be required"
+        "https://github.com/heroku/heroku-buildpack-ruby.git"
+      }
+    }
     HATCHET_BUILDPACK_BRANCH = -> { ENV['HATCHET_BUILDPACK_BRANCH'] || ENV['HEROKU_TEST_RUN_BRANCH'] || Hatchet.git_branch }
-    BUILDPACK_URL = "https://github.com/heroku/heroku-buildpack-ruby.git"
 
     attr_reader :name, :stack, :directory, :repo_name, :app_config, :buildpacks, :reaper, :max_retries_count
 
@@ -85,7 +89,7 @@ module Hatchet
     end
 
     def self.default_buildpack
-      [HATCHET_BUILDPACK_BASE, HATCHET_BUILDPACK_BRANCH.call].join("#")
+      [HATCHET_BUILDPACK_BASE.call, HATCHET_BUILDPACK_BRANCH.call].join("#")
     end
 
     def allow_failure?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,8 @@ RSpec.configure do |config|
   end
 end
 
-ENV['HATCHET_BUILDPACK_BRANCH'] = "master"
+ENV['HATCHET_BUILDPACK_BASE'] = "https://github.com/heroku/heroku-buildpack-ruby.git"
+ENV['HATCHET_BUILDPACK_BRANCH'] = "main"
 
 require 'parallel_tests/test/runtime_logger' if ENV['RECORD_RUNTIME']
 


### PR DESCRIPTION
Currently if you want to set HATCHET_BUILDPACK_BASE, you need to do so before you `require 'hatchet'` which is unexpected. By evaluating this env var every time a new app is created it allows the developer to set this env var when they want instead of before requiring the library.

The other change here is to no longer default to a buildpack. While it was useful for defaulting to the Ruby buildpack when only the ruby buildpack used this library, it is confusing when setting up a new buildpack to have deploys seemingly happen but it to not use your buildpack code. This can be fixed by raising a helpful error when HATCHET_BUILDPACK_BASE is not set. However that's a breaking change. For now I'm just deprecating that fallback behavior.