### PR TITLE
[close #88] Raise error when no source given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Hatchet#new raises a helpful error when no source code location is provided (https://github.com/heroku/hatchet/pull/134)
 - Lazy evaluation of HATCHET_BUILDPACK_BASE env var (https://github.com/heroku/hatchet/pull/133)
 - Deprecating HATCHET_BUILDPACK_BASE default (https://github.com/heroku/hatchet/pull/133)
 - Allow multiple `App#before_deploy` blocks to be set and called (https://github.com/heroku/hatchet/pull/126)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -46,8 +46,9 @@ module Hatchet
     end
 
     SkipDefaultOption = Object.new
+    DEFAULT_REPO_NAME = Object.new
 
-    def initialize(repo_name,
+    def initialize(repo_name = DEFAULT_REPO_NAME,
                    stack: "",
                    name: default_name,
                    debug: nil,
@@ -62,6 +63,7 @@ module Hatchet
                    retries: RETRIES,
                    config: {}
                   )
+      raise "You tried creating a Hatchet::App instance without source code, pass in a path to an app to deploy or the name of an app in your hatchet.json" if repo_name == DEFAULT_REPO_NAME
       @repo_name     = repo_name
       @directory     = self.config.path_for_name(@repo_name)
       @name          = name

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -1,6 +1,10 @@
 require("spec_helper")
 
 describe "AppTest" do
+  it "custom errors when no app passed in" do
+    expect { Hatchet::Runner.new }.to raise_error(/without source code/)
+  end
+
   it "does not modify local files by mistake" do
     Dir.mktmpdir do |dir_1|
       app = Hatchet::Runner.new(dir_1)


### PR DESCRIPTION
```
  14) Java a simple java app on jdk-openjdk-9.0.4 should deploy
      Failure/Error:
        Hatchet::Runner.new(
          buildpacks: ["https://github.com/heroku/heroku-buildpack-java"],
          config: {
            "JVM_COMMON_BUILDPACK" => "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}"
          }
        ).tap do |app|
          # app.before_deploy do
          #   set_java_version(Dir.pwd, version)
          # end
          # app.deploy do

      ArgumentError:
        unknown keywords: :buildpacks, :config
      # /Users/rschneeman/.gem/ruby/2.7.1/gems/heroku_hatchet-6.0.0/lib/hatchet/config.rb:49:in `[]'
      # /Users/rschneeman/.gem/ruby/2.7.1/gems/heroku_hatchet-6.0.0/lib/hatchet/config.rb:49:in `block in path_for_name'
      # /Users/rschneeman/.gem/ruby/2.7.1/gems/heroku_hatchet-6.0.0/lib/hatchet/config.rb:48:in `each'
      # /Users/rschneeman/.gem/ruby/2.7.1/gems/heroku_hatchet-6.0.0/lib/hatchet/config.rb:48:in `detect'
      # /Users/rschneeman/.gem/ruby/2.7.1/gems/heroku_hatchet-6.0.0/lib/hatchet/config.rb:48:in `path_for_name'
      # /Users/rschneeman/.gem/ruby/2.7.1/gems/heroku_hatchet-6.0.0/lib/hatchet/app.rb:40:in `initialize'
      # ./test/spec/java_spec.rb:17:in `new'
      # ./test/spec/java_spec.rb:17:in `block (4 levels) in <top (required)>'
```

This PR defaults to a value then raises an error when that value is not assigned manually by the programmer.