### PR TITLE
Deprecate App#directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- App#directory is deprecated (https://github.com/heroku/hatchet/pull/135)
 - Empty string returns from App#run now trigger retries (https://github.com/heroku/hatchet/pull/132)
 - Annotate rspec expectation failures inside of deploy blocks with hatchet debug information (https://github.com/heroku/hatchet/pull/136)
 - Hatchet#new raises a helpful error when no source code location is provided (https://github.com/heroku/hatchet/pull/134)

--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ end
 > Note: If you want to execute tests in this temp directory, you likely want to use `in_directory_fork` otherwise, you might accidentally contaminate the current environment's variables if you modify them.
 
 - `app.in_directory_fork`: Runs the given block in a temp directory and inside of a forked process, an example given above.
-- `app.directory`: Returns the directory of the example application on disk, this is NOT the temp directory that you're currently executing against. It's probably not what you want.
+- `app.original_source_code_directory`: Returns the directory of the example application on disk, this is NOT the temp directory that you're currently executing against. It's probably not what you want.
 - `app.deploy`: Your main method takes a block to execute after the deploy is successful. If no block is provided, you must manually call `app.teardown!` (see below for an example).
 - `app.output`: The output contents of the deploy
 - `app.platform_api`: Returns an instance of the [platform-api Heroku client](https://github.com/heroku/platform-api). If Hatchet doesn't give you access to a part of Heroku that you need, you can likely do it with the platform-api client.

--- a/lib/hatchet/test_run.rb
+++ b/lib/hatchet/test_run.rb
@@ -1,7 +1,7 @@
 module Hatchet
   class FailedTestError < StandardError
     def initialize(app, output)
-      msg = "Could not run tests on pipeline id: '#{app.pipeline_id}' (#{app.repo_name}) at path: '#{app.directory}'\n" <<
+      msg = "Could not run tests on pipeline id: '#{app.pipeline_id}' (#{app.repo_name}) at path: '#{app.original_source_code_directory}'\n" <<
             " if this was expected add `allow_failure: true` to your hatchet initialization hash.\n" <<
             "output:\n" <<
             "#{output}"


### PR DESCRIPTION
It's confusing that App#directory points to the original source code instead of the temp dir where the source is currently. Let's make this more explicit by deprecating that method.