### PR TITLE
[close #50] Annotate rspec errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Annotate rspec expectation failures inside of deploy blocks with hatchet debug information (https://github.com/heroku/hatchet/pull/136)
 - Hatchet#new raises a helpful error when no source code location is provided (https://github.com/heroku/hatchet/pull/134)
 - Lazy evaluation of HATCHET_BUILDPACK_BASE env var (https://github.com/heroku/hatchet/pull/133)
 - Deprecating HATCHET_BUILDPACK_BASE default (https://github.com/heroku/hatchet/pull/133)

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -1,8 +1,18 @@
 require("spec_helper")
 
 describe "AppTest" do
-  it "custom errors when no app passed in" do
-    expect { Hatchet::Runner.new }.to raise_error(/without source code/)
+  it "annotates rspec expectation failures" do
+    app = Hatchet::Runner.new("default_ruby")
+    error = nil
+    begin
+      app.annotate_failures do
+        expect(true).to eq(false)
+      end
+    rescue RSpec::Expectations::ExpectationNotMetError => e
+      error = e
+    end
+
+    expect(error.message).to include(app.name)
   end
 
   it "does not modify local files by mistake" do


### PR DESCRIPTION
For intermittent failures it's important to get as much debugging information as possible about the test in progress. This PR annotates any rspec expectation failures that happen in a `deploy {}` block with the application name. Here's an example of what it will look like:

```
     Failure/Error: expect(true).to eq(false)

       App: hatchet-t-873bcea87c (default_ruby)

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true
``` 


In this example if the failure was due to an `app.run` then we could manually `app.run` against the same app (assuming it had not been reaped yet) in order to better debug.