### PR TITLE
Don't use &.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## HEAD
 
+## 7.3.1
+
+- Fix Ruby incompatibility introduced by using `&.` and `rescue` without
+  `begin`/`end` without a `required_ruby_version` in hatchet.gemspec.
+  (https://github.com/heroku/hatchet/pull/139)
+
 ## 7.3.0
 
 - Deprecations

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -52,7 +52,7 @@ class HatchetCLI < Thor
       Threaded.later do
         commit = lock_hash[directory]
         directory = File.expand_path(directory)
-        if !Dir[directory]&.empty?
+        if !(Dir[directory] && Dir[directory].empty?)
           puts "== pulling '#{git_repo}' into '#{directory}'\n"
           pull(directory, git_repo)
         else

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -8,7 +8,7 @@
 - - repo_fixtures/repos/default/default_ruby
   - 6e642963acec0ff64af51bd6fba8db3c4176ed6e
 - - repo_fixtures/repos/lock/lock_fail
-  - da748a59340be8b950e7bbbfb32077eb67d70c3c
+  - e61ba47043fbae131abb74fd74added7e6e504df
 - - repo_fixtures/repos/lock/lock_fail_main
   - main
 - - repo_fixtures/repos/lock/lock_fail_master

--- a/lib/hatchet/config.rb
+++ b/lib/hatchet/config.rb
@@ -46,7 +46,7 @@ module Hatchet
     def path_for_name(name)
       possible_paths = [repos[name.to_s], "repos/#{name}", name].compact
       path = possible_paths.detect do |path|
-        !Dir[path]&.empty?
+        !(Dir[path] && Dir[path].empty?)
       end
       raise BadRepoName.new(name, possible_paths) if path.nil? || path.empty?
       path

--- a/lib/hatchet/git_app.rb
+++ b/lib/hatchet/git_app.rb
@@ -9,14 +9,16 @@ module Hatchet
       output = ""
 
       ShellThrottle.new(platform_api: @platform_api).call do
-        output = git_push_heroku_yall
-      rescue FailedDeploy => e
-        case e.output
-        when /reached the API rate limit/, /429 Too Many Requests/
-          throw(:throttle)
-        else
-          raise e unless @allow_failure
-          output = e.output
+        begin
+          output = git_push_heroku_yall
+        rescue FailedDeploy => e
+          case e.output
+          when /reached the API rate limit/, /429 Too Many Requests/
+            throw(:throttle)
+          else
+            raise e unless @allow_failure
+            output = e.output
+          end
         end
       end
 

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "7.3.0"
+  VERSION = "7.3.1"
 end


### PR DESCRIPTION
We don't specify a required_ruby_version, so this change makes Hatchet
incompatible with Ruby pre-2.7. That causes platform-api's tests to fail
as they test against Rubies back to 2.2.

See for example [this failing CircleCI job](https://app.circleci.com/pipelines/github/heroku/platform-api/79/workflows/ec4d33f1-8596-4604-a742-59beec4951d7/jobs/428).

This should resolve the fialing builds on
https://github.com/heroku/platform-api/pull/110.