### PR TITLE
create CI slug tarball outside cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Do not create CI tarball inside cwd to prevent tar "file changed as we read it" warnings.
+
 ## 7.3.1
 
 - Fix Ruby incompatibility introduced by using `&.` and `rescue` without


### PR DESCRIPTION
Otherwise, tar will often say 'file changed as we read it' because it's packing up the contents of the directory, and the directory suddenly contains the tarball itself as a new file