### PR TITLE
Fix debug output for `in_directory_fork`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Fix App#in_directory_fork not receiving debugging output when an error is raised (https://github.com/heroku/hatchet/pull/146)
 - Do not create CI tarball inside cwd to prevent tar "file changed as we read it" warnings.
 
 ## 7.3.1

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -387,8 +387,8 @@ module Hatchet
     def in_directory_fork(&block)
       Tempfile.create("stdout") do |tmp_file|
         pid = fork do
-          $stdout.reopen(tmp_file, "w")
-          $stderr.reopen(tmp_file, "w")
+          $stdout.reopen(tmp_file, "a")
+          $stderr.reopen(tmp_file, "a")
           $stdout.sync = true
           $stderr.sync = true
           in_directory do |dir|

--- a/spec/hatchet/local_repo_spec.rb
+++ b/spec/hatchet/local_repo_spec.rb
@@ -11,6 +11,15 @@ describe "LocalRepoTest" do
     expect(ENV[env_name]).to eq(env_name)
   end
 
+  it "in directory fork captures stdout even when there is an error" do
+    expect {
+      Hatchet::App.new("default_ruby").in_directory_fork do
+        puts "hello_there"
+        raise "error"
+      end
+    }.to raise_error(/hello_there/)
+  end
+
   it "repos checked into git" do
     begin
       fixture_dir = "repo_fixtures/different-folder-for-checked-in-repos/default_ruby"


### PR DESCRIPTION
When an error is raised inside of `in_directory_fork` it writes over the existing contents so if there's any debug output that was added it gets written over. 

This fixes that behavior by making stdout and stderr append to the log file instead of