### PR TITLE
[close #147] Quiet API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Quiet personal tokens (https://github.com/heroku/hatchet/pull/148)
+
 ## 7.3.2
 
 - Fix App#in_directory_fork not receiving debugging output when an error is raised (https://github.com/heroku/hatchet/pull/146)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -446,7 +446,7 @@ module Hatchet
     end
 
     def api_key
-      @api_key ||= ENV['HEROKU_API_KEY'] ||= `heroku auth:token`.chomp
+      @api_key ||= ENV['HEROKU_API_KEY'] ||= `heroku auth:token 2> /dev/null`.chomp
     end
 
     def heroku


### PR DESCRIPTION
From this:

```
$ be rspec spec/unit
.... ›   Warning: token will expire 10/15/2021
 ›   Use heroku authorizations:create to generate a long-term token

..............

Finished in 20.48 seconds (files took 0.42776 seconds to load)
18 examples, 0 failures
```

To this:

```
$ be rspec spec/unit
..................

Finished in 20.48 seconds (files took 0.42776 seconds to load)
18 examples, 0 failures
```