### PR TITLE
HerokuRun improvements: thread safety, timeout support, status return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Delay for empty/timeout retries if run_multi is off, defaults to 1 s, global override `$HATCHET_RUN_RETRY_DELAY`
 - Record and print dyno id ("run.1234") in event of empty output or timeout retry
 - Terminate dyno via API on timeout
+- Allow returning of entire run object in App#run (to access process status) using :return_obj => true option
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Refactor run_shell! to use Open3.popen3 in preparation for timeout handling
 - Timeout support for 'heroku run' (in case of networking, hanging or "server boot" tests etc), defaults to 60 s, global override `$HATCHET_DEFAULT_RUN_TIMEOUT`, per-test option `:timeout`
 - Delay for empty/timeout retries if run_multi is off, defaults to 1 s, global override `$HATCHET_RUN_RETRY_DELAY`
+- Record and print dyno id ("run.1234") in event of empty output or timeout retry
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Timeout support for 'heroku run' (in case of networking, hanging or "server boot" tests etc), defaults to 60 s, global override `$HATCHET_DEFAULT_RUN_TIMEOUT`, per-test option `:timeout`
 - Delay for empty/timeout retries if run_multi is off, defaults to 1 s, global override `$HATCHET_RUN_RETRY_DELAY`
 - Record and print dyno id ("run.1234") in event of empty output or timeout retry
+- Terminate dyno via API on timeout
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 - Add support for GitHub Actions env vars (https://github.com/heroku/hatchet/pull/189)
+- Change HerokuRun#call to use exceptions for empty output retries in preparation of related work
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support for GitHub Actions env vars (https://github.com/heroku/hatchet/pull/189)
 - Change HerokuRun#call to use exceptions for empty output retries in preparation of related work
 - Refactor run_shell! to use Open3.popen3 in preparation for timeout handling
+- Timeout support for 'heroku run' (in case of networking, hanging or "server boot" tests etc), defaults to 60 s, global override `$HATCHET_DEFAULT_RUN_TIMEOUT`, per-test option `:timeout`
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Change HerokuRun#call to use exceptions for empty output retries in preparation of related work
 - Refactor run_shell! to use Open3.popen3 in preparation for timeout handling
 - Timeout support for 'heroku run' (in case of networking, hanging or "server boot" tests etc), defaults to 60 s, global override `$HATCHET_DEFAULT_RUN_TIMEOUT`, per-test option `:timeout`
+- Delay for empty/timeout retries if run_multi is off, defaults to 1 s, global override `$HATCHET_RUN_RETRY_DELAY`
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add support for GitHub Actions env vars (https://github.com/heroku/hatchet/pull/189)
 - Change HerokuRun#call to use exceptions for empty output retries in preparation of related work
+- Refactor run_shell! to use Open3.popen3 in preparation for timeout handling
 
 ## 7.4.0
 

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -199,7 +199,7 @@ module Hatchet
         timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
       ).call
 
-      return run_obj.output
+      return options[:return_obj] ? run_obj : run_obj.output
     end
 
     private def allow_run_multi!

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -194,7 +194,8 @@ module Hatchet
         app: self,
         retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
         heroku: options[:heroku],
-        raw: options[:raw]
+        raw: options[:raw],
+        timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
       ).call
 
       return run_obj.output
@@ -248,7 +249,8 @@ module Hatchet
           app: self,
           retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
           heroku: options[:heroku],
-          raw: options[:raw]
+          raw: options[:raw],
+          timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
         ).call
 
         yield run_obj.output, run_obj.status

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -193,6 +193,7 @@ module Hatchet
         command,
         app: self,
         retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
+        retry_delay: @run_multi ? 0 : (ENV["HATCHET_RUN_RETRY_DELAY"] || 1).to_i,
         heroku: options[:heroku],
         raw: options[:raw],
         timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)
@@ -248,6 +249,7 @@ module Hatchet
           command,
           app: self,
           retry_on_empty: options.fetch(:retry_on_empty, !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"]),
+          retry_delay: @run_multi ? 0 : (ENV["HATCHET_RUN_RETRY_DELAY"] || 1).to_i,
           heroku: options[:heroku],
           raw: options[:raw],
           timeout: options.fetch(:timeout, (ENV["HATCHET_DEFAULT_RUN_TIMEOUT"] || 60).to_i)

--- a/lib/hatchet/heroku_run.rb
+++ b/lib/hatchet/heroku_run.rb
@@ -1,19 +1,33 @@
 require 'open3'
+require 'timeout'
 
 module Hatchet
   class BashResult
-    attr_reader :stdout, :stderr, :status
+    attr_reader :stdout, :stderr, :status, :status_obj
 
     def initialize(stdout:, stderr:, status:, set_global_status: false)
       @stdout = stdout
       @stderr = stderr
-      @status = status.respond_to?(:exitstatus) ? status.exitstatus : status.to_i
-      `exit #{@status}` if set_global_status
+      @status_obj = status
+      @status = @status_obj.exitstatus
+      return unless set_global_status
+      # we're now populating `$?` by hand for any callers that rely on that
+      if @status_obj.signaled?
+        # termination of 'heroku run' from our TERM signal
+        # a signaled program will not have an exit status
+        # the shell just represents that case as 128+$signal, so e.g. 128+15=143 for SIGTERM
+        # the correct behavior for a program is to terminate itself using the signal it received
+        # this will also produce the correct $? contents (signaled? again, termsig set, no exitstatus)
+        `kill -#{@status_obj.termsig} $$`
+      else
+        # the dyno exited and the CLI is reporting that back as an exit status
+        `exit #{@status}`
+      end
     end
 
     # @return [Boolean]
     def success?
-      @status == 0
+      @status_obj.success?
     end
 
     def failed?
@@ -49,6 +63,7 @@ module Hatchet
   #
   class HerokuRun
     class HerokuRunEmptyOutputError < RuntimeError; end
+    class HerokuRunTimeoutError < RuntimeError; end
 
     attr_reader :command
 
@@ -58,15 +73,19 @@ module Hatchet
       heroku: {},
       retry_on_empty: !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"],
       raw: false,
-      stderr: $stderr)
+      stderr: $stderr,
+      timeout: 0)
 
       @raw = raw
       @app = app
+      @timeout = timeout
       @command = build_heroku_command(command, heroku || {})
       @retry_on_empty = retry_on_empty
       @stderr = stderr
       @result = nil
+      @dyno_id = nil
       @empty_fail_count = 0
+      @timeout_fail_count = 0
     end
 
     def result
@@ -89,9 +108,22 @@ module Hatchet
       rescue HerokuRunEmptyOutputError => e
         if @retry_on_empty and @empty_fail_count < 3
           @empty_fail_count += 1
-          message = String.new("Empty output from command #{@command}, retrying the command.")
+          message = String.new("Empty output from run #{@dyno_id} with command #{@command}, retrying...")
           message << "\nTo disable pass in `retry_on_empty: false` or set HATCHET_DISABLE_EMPTY_RUN_RETRY=1 globally"
           message << "\nfailed_count: #{@empty_fail_count}"
+          message << "\nreleases: #{@app.releases}"
+          message << "\n#{caller.join("\n")}"
+          @stderr.puts message
+          retry
+        end
+      rescue HerokuRunTimeoutError => e
+        if @timeout_fail_count < 3
+          @timeout_fail_count += 1
+          message = String.new("Run #{@dyno_id} with command #{@command} timed out after #{@timeout} seconds, retrying...")
+          message << "\nstderr until moment of termination was: #{@result.stderr}"
+          message << "\nstdout until moment of termination was: #{@result.stdout}"
+          message << "\nTo disable pass in `timeout: 0` or set HATCHET_DEFAULT_RUN_TIMEOUT=0 globally"
+          message << "\nfailed_count: #{@timeout_fail_count}"
           message << "\nreleases: #{@app.releases}"
           message << "\n#{caller.join("\n")}"
           @stderr.puts message
@@ -106,6 +138,7 @@ module Hatchet
       ShellThrottle.new(platform_api: @app.platform_api).call do |throttle|
         run_shell!
         throw(:throttle) if @result.stderr.match?(/reached the API rate limit/)
+        raise HerokuRunTimeoutError if @result.status_obj.signaled? # program got terminated by our SIGTERM, raise
         raise HerokuRunEmptyOutputError if @result.stdout.empty?
       end
     end
@@ -113,27 +146,38 @@ module Hatchet
     private def run_shell!
       r_stdout = ""
       r_stderr = ""
+      r_status = nil
+      @dyno_id = nil
       Open3.popen3(@command) do |stdin, stdout, stderr, wait_thread|
-        Thread.new do
-          begin
-            until stdout.eof? do
-              r_stdout += stdout.gets
+        begin
+          Timeout.timeout(@timeout) do
+            Thread.new do
+              begin
+                until stdout.eof? do
+                  r_stdout += stdout.gets
+                end
+              rescue IOError # eof? and gets race condition
+              end
             end
-          rescue IOError # eof? and gets race condition
-          end
-        end
-        Thread.new do
-          begin
-            until stderr.eof? do
-              r_stderr += stderr.gets
+            Thread.new do
+              begin
+                until stderr.eof? do
+                  r_stderr += line = stderr.gets
+                  if !@dyno_id and run = line.match(/, (run\.\d+)/)
+                    @dyno_id = run.captures.first
+                  end
+                end
+              rescue IOError # eof? and gets race condition
+              end
             end
-          rescue IOError # eof? and gets race condition
           end
+          r_status = wait_thread.value # wait for termination
+        rescue Timeout::Error
+          Process.kill("TERM", wait_thread.pid)
+          r_status = wait_thread.value # wait for termination
         end
-        r_status = wait_thread.value # wait for termination
       end
       @result = BashResult.new(stdout: r_stdout, stderr: r_stderr, status: r_status, set_global_status: true)
-      # FIXME: usage of $? does not allow a test to distinguish between a TERM of the 'heroku run' itself, or inside the dyno
       @status = $?
     end
 

--- a/lib/hatchet/heroku_run.rb
+++ b/lib/hatchet/heroku_run.rb
@@ -119,6 +119,7 @@ module Hatchet
           sleep(@retry_delay) # without run_multi, this will prevent occasional "can only run one free dyno" errors
           retry
         end
+        raise # we are out of retries
       rescue HerokuRunTimeoutError => e
         if @timeout_fail_count < 3
           @timeout_fail_count += 1
@@ -134,6 +135,7 @@ module Hatchet
           sleep(@retry_delay) # without run_multi, this will prevent occasional "can only run one free dyno" errors
           retry
         end
+        raise # we are out of retries
       end
 
       self

--- a/lib/hatchet/heroku_run.rb
+++ b/lib/hatchet/heroku_run.rb
@@ -122,7 +122,7 @@ module Hatchet
       rescue HerokuRunTimeoutError => e
         if @timeout_fail_count < 3
           @timeout_fail_count += 1
-          message = String.new("Run #{@dyno_id} with command #{@command} timed out after #{@timeout} seconds, retrying...")
+          message = String.new("Run #{@dyno_id} with command #{@command} timed out after #{@timeout} seconds, stopping dyno and retrying...")
           message << "\nstderr until moment of termination was: #{@result.stderr}"
           message << "\nstdout until moment of termination was: #{@result.stdout}"
           message << "\nTo disable pass in `timeout: 0` or set HATCHET_DEFAULT_RUN_TIMEOUT=0 globally"
@@ -130,6 +130,7 @@ module Hatchet
           message << "\nreleases: #{@app.releases}"
           message << "\n#{caller.join("\n")}"
           @stderr.puts message
+          @app.platform_api.dyno.stop(@app.name, @dyno_id) if @dyno_id
           sleep(@retry_delay) # without run_multi, this will prevent occasional "can only run one free dyno" errors
           retry
         end

--- a/lib/hatchet/heroku_run.rb
+++ b/lib/hatchet/heroku_run.rb
@@ -72,6 +72,7 @@ module Hatchet
       app: ,
       heroku: {},
       retry_on_empty: !ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"],
+      retry_delay: 0,
       raw: false,
       stderr: $stderr,
       timeout: 0)
@@ -81,6 +82,7 @@ module Hatchet
       @timeout = timeout
       @command = build_heroku_command(command, heroku || {})
       @retry_on_empty = retry_on_empty
+      @retry_delay = retry_delay
       @stderr = stderr
       @result = nil
       @dyno_id = nil
@@ -114,6 +116,7 @@ module Hatchet
           message << "\nreleases: #{@app.releases}"
           message << "\n#{caller.join("\n")}"
           @stderr.puts message
+          sleep(@retry_delay) # without run_multi, this will prevent occasional "can only run one free dyno" errors
           retry
         end
       rescue HerokuRunTimeoutError => e
@@ -127,6 +130,7 @@ module Hatchet
           message << "\nreleases: #{@app.releases}"
           message << "\n#{caller.join("\n")}"
           @stderr.puts message
+          sleep(@retry_delay) # without run_multi, this will prevent occasional "can only run one free dyno" errors
           retry
         end
       end

--- a/spec/unit/heroku_run_spec.rb
+++ b/spec/unit/heroku_run_spec.rb
@@ -59,7 +59,7 @@ describe "HerokuRun" do
       run_obj.call
 
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(3)
-      expect(stderr.string).to include("retrying...")
+      expect(stderr.string).to include("now retrying execution")
     end
 
     it "retries 0 times on NON empty result" do
@@ -93,7 +93,7 @@ describe "HerokuRun" do
       run_obj.call
 
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
-      expect(stderr.string).to_not include("retrying...")
+      expect(stderr.string).to_not include("now retrying execution")
     end
 
     it "retries work when message is delivered via stderr" do
@@ -131,7 +131,7 @@ describe "HerokuRun" do
         run_obj.call
 
         expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
-        expect(stderr.string).to_not include("retrying...")
+        expect(stderr.string).to_not include("now retrying execution")
       ensure
         ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"] = original_env
       end

--- a/spec/unit/heroku_run_spec.rb
+++ b/spec/unit/heroku_run_spec.rb
@@ -50,14 +50,16 @@ describe "HerokuRun" do
       run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr)
 
       def run_obj.run_shell!
-        @result = Hatchet::BashResult.new(stdout: "", stderr: "", status: 1)
-        @status = Object.new
+        # to populate $? with a correct status variable
+        `exit 1`
+        @result = Hatchet::BashResult.new(stdout: "", stderr: "", status: $?)
+        @status = $?
       end
 
       run_obj.call
 
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(3)
-      expect(stderr.string).to include("retrying the command.")
+      expect(stderr.string).to include("retrying...")
     end
 
     it "retries 0 times on NON empty result" do
@@ -65,8 +67,10 @@ describe "HerokuRun" do
       run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr)
 
       def run_obj.run_shell!
-        @result = Hatchet::BashResult.new(stdout: "not empty", stderr: "", status: 1)
-        @status = Object.new
+        # to populate $? with a correct status variable
+        `exit 1`
+        @result = Hatchet::BashResult.new(stdout: "not empty", stderr: "", status: $?)
+        @status = $?
       end
 
       run_obj.call
@@ -80,14 +84,16 @@ describe "HerokuRun" do
       run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr, retry_on_empty: false)
 
       def run_obj.run_shell!
-        @result = Hatchet::BashResult.new(stdout: "", stderr: "", status: 1)
-        @status = Object.new
+        # to populate $? with a correct status variable
+        `exit 1`
+        @result = Hatchet::BashResult.new(stdout: "", stderr: "", status: $?)
+        @status = $?
       end
 
       run_obj.call
 
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
-      expect(stderr.string).to_not include("retrying the command.")
+      expect(stderr.string).to_not include("retrying...")
     end
 
     it "retries work when message is delivered via stderr" do
@@ -116,14 +122,16 @@ describe "HerokuRun" do
         run_obj = Hatchet::HerokuRun.new("ruby -v", app: @app, stderr: stderr)
 
         def run_obj.run_shell!
-          @result = Hatchet::BashResult.new(stdout: "", stderr: "", status: 1)
-          @status = Object.new
+          # to populate $? with a correct status variable
+          `exit 1`
+          @result = Hatchet::BashResult.new(stdout: "", stderr: "", status: $?)
+          @status = $?
         end
 
         run_obj.call
 
         expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
-        expect(stderr.string).to_not include("retrying the command.")
+        expect(stderr.string).to_not include("retrying...")
       ensure
         ENV["HATCHET_DISABLE_EMPTY_RUN_RETRY"] = original_env
       end

--- a/spec/unit/heroku_run_spec.rb
+++ b/spec/unit/heroku_run_spec.rb
@@ -56,8 +56,7 @@ describe "HerokuRun" do
         @status = $?
       end
 
-      run_obj.call
-
+      expect { run_obj.call }.to raise_error(Hatchet::HerokuRun::HerokuRunEmptyOutputError)
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(3)
       expect(stderr.string).to include("now retrying execution")
     end
@@ -73,8 +72,7 @@ describe "HerokuRun" do
         @status = $?
       end
 
-      run_obj.call
-
+      expect { run_obj.call }.not_to raise_error(Hatchet::HerokuRun::HerokuRunEmptyOutputError)
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
       expect(run_obj.output).to eq("not empty")
     end
@@ -90,8 +88,7 @@ describe "HerokuRun" do
         @status = $?
       end
 
-      run_obj.call
-
+      expect { run_obj.call }.to raise_error(Hatchet::HerokuRun::HerokuRunEmptyOutputError)
       expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
       expect(stderr.string).to_not include("now retrying execution")
     end
@@ -128,8 +125,7 @@ describe "HerokuRun" do
           @status = $?
         end
 
-        run_obj.call
-
+        expect { run_obj.call }.to raise_error(Hatchet::HerokuRun::HerokuRunEmptyOutputError)
         expect(run_obj.instance_variable_get(:@empty_fail_count)).to eq(0)
         expect(stderr.string).to_not include("now retrying execution")
       ensure


### PR DESCRIPTION
## why

As explained in #157, backticks followed by `$?` access aren't threadsafe, which may cause trouble when using `run_multi`. There also isn't a way for tests to get the exit status of a `heroku run` without using `$?`, which is an implementational detail internal to Hatchet due to the usage of backticks for shelling out.

We also want support for timeouts - sometimes, `heroku run`s can hang for a long time for various reasons.

## thread safety fix
This new implementation uses Open3 to shell out to `heroku run`, and because it captures stderr separately, it paves a possible way for fixing #156 as well.

## timeouts
A new `:timeout` argument, defaulting to 60 seconds, will terminate a hanging or slow `heroku run`, because sometimes dynos do not connect (and the Heroku CLI timeout is hardcoded to one hour), sometimes tests hang, and sometimes tests that are supposed to not boot a web server will suddenly boot a web server after all and then sit there forever.

The timeout functionality now successfully prevents flappy failures for the PHP buildpack:

```
[TEST GROUP 8] Running ./waitforit.sh 15 'ready for connections' heroku-php-apache2 --verbose on htcht-453589629-d79bb6e18f... starting, run.9601 (Standard-1X)
…
[TEST GROUP 8] Run run.9601 with command heroku run --app=htcht-453589629-d79bb6e18f --exit-code --env=WEB_CONCURRENCY\=22 -- ./waitforit.sh\ 15\ \'ready\ for\ connections\'\ heroku-php-apache2\ --verbose timed out after 60 seconds, stopping dyno and retrying...
[TEST GROUP 8] Running ./waitforit.sh 15 'ready for connections' heroku-php-apache2 --verbose on htcht-453589629-d79bb6e18f... starting, run.1440 (Standard-1X)
[TEST GROUP 8] Running ./waitforit.sh 15 'ready for connections' heroku-php-apache2 --verbose on htcht-453589629-d79bb6e18f... connecting, run.1440 (Standard-1X)
[TEST GROUP 8] Running ./waitforit.sh 15 'ready for connections' heroku-php-apache2 --verbose on htcht-453589629-d79bb6e18f... up, run.1440 (Standard-1X)
[TEST GROUP 8] .
```

## retries

Both timeout and empty output retries are now implemented using exceptions rather than a loop.

Both will sleep for a default of one second if `run_multi` is off, preventing possible "can only run one free dyno" errors on retry.

## dyno ID capture

From the now separately captured stderr, the dyno ID ("`run.1234`") is extracted and printed on retry, possibly aiding debugging.

We could also consider not printing stderr at all until an error has occured, resulting in much cleaner test output because all the `heroku run` etc output is gone.

## backwards compatibility considerations
For what may be considered BC, we still set `$?` by running a quick `kill` or `exit` with the appropriate signal or code in backticks (depending on whether the program was signaled or not; this allows distinguishing between the two cases, as e.g. `termsig`=15 means the `heroku run` got killed, and `exitstatus=143` means the dyno run was `SIGTERM`inated).

This is not threadsafe, but allows any tests that have relied on the previous internal implementation (implemented using backticks) to continue to work until they are migrated to an alternative way of getting the exit status of a `heroku run` (see next section).

Generally, breaking the use of `$?` in tests shouldn't be considered a critical BC break, as tests should not rely on internal implementation details of Hatchet, so this should be removed soon.

## exit status
Right now, this alternative way of getting the exit status of a `heroku run` is an argument to `run` that changes its return value: if `:return_obj => true` is given as an option, the return value is the whole `HerokuRun` object rather than just the output string, allowing access to `.output` and `.status`.

I tried returning the object and giving the class `to_s` and `to_str` methods, but `match()` etc do not trigger those, so it would break basically every test out there.

### alternatives
Alternatively, we could have new method that returns the whole object, and the old `run` just wraps that.

For reference, `run_multi` yields a block with `output` and `status` arguments. Maybe something similar to that?

## tests
Tests will be added to this PR, I just wanted to get a general +1 first before I weave them in.

## review
Please review this by also following the commits in chronological order, I've taken extra care to make the "journey" clear.

