### PR TITLE
Use the standalone installer for 'ci:install_heroku' rather than APT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Switch `heroku ci:install_heroku` to the Heroku CLI standalone installer rather than the APT install method (https://github.com/heroku/hatchet/issues/171)
+
 ## 7.3.3
 
 - Quiet personal tokens (https://github.com/heroku/hatchet/pull/148)

--- a/etc/setup_heroku.sh
+++ b/etc/setup_heroku.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install-ubuntu.sh | sh
+curl --fail --retry 3 --retry-delay 1 --connect-timeout 3 --max-time 30 https://cli-assets.heroku.com/install.sh | sh


### PR DESCRIPTION
Since the APT installer takes 3.5x longer than the non-APT version, and offers little benefit in a CI environment.

Closes #169.