### PR TITLE
Set 'init.defaultBranch' in ci:setup to suppress 'git init' warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Set `init.defaultBranch` in ci:setup to suppress `git init` warning in Git 2.30+ (https://github.com/heroku/hatchet/issues/172)
+
 ## 7.3.3
 
 - Quiet personal tokens (https://github.com/heroku/hatchet/pull/148)

--- a/etc/ci_setup.rb
+++ b/etc/ci_setup.rb
@@ -30,6 +30,8 @@ run_cmd "bundle exec hatchet ci:install_heroku"
 run_cmd "bundle exec hatchet install"
 run_cmd "git config --get user.email > /dev/null || git config --global user.email #{ENV.fetch('HEROKU_API_USER').shellescape}"
 run_cmd "git config --get user.name > /dev/null || git config --global user.name 'BuildpackTester'"
+# Suppress the `git init` warning in Git 2.30+ when no default branch name is set.
+run_cmd "git config --global init.defaultBranch main"
 
 puts "== Done =="
 


### PR DESCRIPTION
In Git 2.30+, the `git init` command outputs a warning if `init.defaultBranch` is not set in the Git configuration:
https://github.com/git/git/commit/675704c74dd4476f455bfa91e72eb9e163317c10

Setting this default in `ci:setup` ensures that the warning does not spam CI logs every time `git init` is run.

This config change only affects new repos created by `git init`, not repositories cloned using `git clone`. Hatchet uses `git init` when the path passed to `App.new` is a local directory, and not a repository cloned via `hatchet.lock`.

This changes the default branch for new repos from `master` to `main`, however this works without further changes, since Hatchet already uses `git push HEAD:main`, where `HEAD` will reference the current branch regardless of its choice of name.

This change is also compatible with older versions of Git, since they ignore unknown config file entries.

Fixes #165.