### PR TITLE
Fix typo in the reaper "Duplicate destroy attempted" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Fix typo in the reaper `"Duplicate destroy attempted"` message (https://github.com/heroku/hatchet/pull/175)
+
 ## 7.3.3
 
 - Quiet personal tokens (https://github.com/heroku/hatchet/pull/148)

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -170,14 +170,14 @@ module Hatchet
       body = e.response.body
       request_id = e.response.headers["Request-Id"]
       if body =~ /Couldn\'t find that app./
-        io.puts "Duplicate destoy attempted #{name.inspect}: #{id}, status: 404, request_id: #{request_id}"
+        io.puts "Duplicate destroy attempted #{name.inspect}: #{id}, status: 404, request_id: #{request_id}"
         raise AlreadyDeletedError.new
       else
         raise e
       end
     rescue Excon::Error::Forbidden => e
       request_id = e.response.headers["Request-Id"]
-      io.puts "Duplicate destoy attempted #{name.inspect}: #{id}, status: 403, request_id: #{request_id}"
+      io.puts "Duplicate destroy attempted #{name.inspect}: #{id}, status: 403, request_id: #{request_id}"
       raise AlreadyDeletedError.new
     end
 


### PR DESCRIPTION
`s/destoy/destroy/`