### PR TITLE
Fix repository path lookup when custom Hatchet directory set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Fix repository path lookup when custom Hatchet directory set (https://github.com/heroku/hatchet/issues/181)
 - Fix typo in the reaper `"Duplicate destroy attempted"` message (https://github.com/heroku/hatchet/pull/175)
 - Set `init.defaultBranch` in ci:setup to suppress `git init` warning in Git 2.30+ (https://github.com/heroku/hatchet/issues/172)
 - Switch `heroku ci:install_heroku` to the Heroku CLI standalone installer rather than the APT install method (https://github.com/heroku/hatchet/issues/171)

--- a/lib/hatchet/config.rb
+++ b/lib/hatchet/config.rb
@@ -44,7 +44,7 @@ module Hatchet
 
     # use this method to turn "codetriage" into repos/rails3/codetriage
     def path_for_name(name)
-      possible_paths = [repos[name.to_s], "repos/#{name}", name].compact
+      possible_paths = [repos[name.to_s], "#{repo_directory_path}/#{name}", name].compact
       path = possible_paths.detect do |path|
         !(Dir[path] && Dir[path].empty?)
       end

--- a/spec/hatchet/config_spec.rb
+++ b/spec/hatchet/config_spec.rb
@@ -6,6 +6,10 @@ describe "ConfigTest" do
     expect(@config.path_for_name("rails3_mri_193")).to(eq("repo_fixtures/repos/rails3/rails3_mri_193"))
   end
 
+  it("config path for name with full repo name") do
+    expect(@config.path_for_name("rails3/rails3_mri_193")).to(eq("repo_fixtures/repos/rails3/rails3_mri_193"))
+  end
+
   it("config dirs") do
     { "repo_fixtures/repos/bundler/no_lockfile" => "https://github.com/sharpstone/no_lockfile.git", "repo_fixtures/repos/default/default_ruby" => "https://github.com/sharpstone/default_ruby.git", "repo_fixtures/repos/rails2/rails2blog" => "https://github.com/sharpstone/rails2blog.git", "repo_fixtures/repos/rails3/rails3_mri_193" => "https://github.com/sharpstone/rails3_mri_193.git" }.each do |key, value|
       assert_include(key, value, @config.dirs)


### PR DESCRIPTION
Previously if a custom Hatchet `directory` was defined in `hatchet.json`, passing a fixture name of the full repository name would not work.

Fixes #161.