### PR TITLE
Memoize Hatchet::App.default_buildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD
 
-
+- Memoize `Hatchet::App.default_buildpack` (https://github.com/heroku/hatchet/pull/183)
 - Fix repository path lookup when custom Hatchet directory set (https://github.com/heroku/hatchet/issues/181)
 - Handle additional variations of rate limit error messages (https://github.com/heroku/hatchet/pull/182)
 - Add `HATCHET_DEFAULT_STACK` for configuring the default stack (https://github.com/heroku/hatchet/pull/184)

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -112,8 +112,9 @@ module Hatchet
       @directory
     end
 
+    @default_buildpack = nil
     def self.default_buildpack
-      [HATCHET_BUILDPACK_BASE.call, HATCHET_BUILDPACK_BRANCH.call].join("#")
+      @default_buildpack ||= [HATCHET_BUILDPACK_BASE.call, HATCHET_BUILDPACK_BRANCH.call].join("#")
     end
 
     def allow_failure?

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -58,6 +58,10 @@ describe "AppTest" do
     expect(app.buildpacks.first).to match("https://github.com/heroku/heroku-buildpack-ruby")
   end
 
+  it "default_buildpack is only computed once" do
+    expect(Hatchet::App.default_buildpack.object_id).to eq(Hatchet::App.default_buildpack.object_id)
+  end
+
   it "create app with stack" do
     stack = "heroku-16"
     app = Hatchet::App.new("default_ruby", stack: stack)


### PR DESCRIPTION
To improve performance and so that it still returns the correct result if called again inside an `app.deploy` block.

Fixes #180.