### PR TITLE
Add branch detection for more CI providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Add support for GitHub Actions env vars (https://github.com/heroku/hatchet/pull/189)
 - Breaking: Support for Ruby 2.2 is soft removed going forward only Ruby versions on the currently relased stack will be supported
 - Bugfix: `heroku run` calls are now properly rate throttled and retried https://github.com/heroku/hatchet/pull/187
 

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -26,6 +26,12 @@ module Hatchet
   Runner  = Hatchet::GitApp
 
   def self.git_branch
+    # https://circleci.com/docs/variables
+    return ENV['CIRCLE_BRANCH'] if ENV['CIRCLE_BRANCH']
+    # https://docs.github.com/en/actions/learn-github-actions/environment-variables
+    return ENV['GITHUB_REF_NAME'] if ENV['GITHUB_REF_NAME']
+    # https://devcenter.heroku.com/articles/heroku-ci#immutable-environment-variables
+    return ENV['HEROKU_TEST_RUN_BRANCH'] if ENV['HEROKU_TEST_RUN_BRANCH']
     # TRAVIS_BRANCH works fine unless the build is a pull-request. In that case, it will contain the target branch
     # not the actual pull-request branch! TRAVIS_PULL_REQUEST_BRANCH contains the correct branch but will be empty
     # for push builds. See: https://docs.travis-ci.com/user/environment-variables/

--- a/lib/hatchet.rb
+++ b/lib/hatchet.rb
@@ -29,6 +29,9 @@ module Hatchet
     # https://circleci.com/docs/variables
     return ENV['CIRCLE_BRANCH'] if ENV['CIRCLE_BRANCH']
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables
+    # GITHUB_HEAD_REF is provided for PRs, but blank for branch actions.
+    return ENV['GITHUB_HEAD_REF'] if !ENV['GITHUB_HEAD_REF'].empty?
+    # GITHUB_REF_NAME is incorrect on PRs (`1371/merge`), but correct for branch actions.
     return ENV['GITHUB_REF_NAME'] if ENV['GITHUB_REF_NAME']
     # https://devcenter.heroku.com/articles/heroku-ci#immutable-environment-variables
     return ENV['HEROKU_TEST_RUN_BRANCH'] if ENV['HEROKU_TEST_RUN_BRANCH']

--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -11,7 +11,7 @@ module Hatchet
         "https://github.com/heroku/heroku-buildpack-ruby.git"
       }
     }
-    HATCHET_BUILDPACK_BRANCH = -> { ENV['HATCHET_BUILDPACK_BRANCH'] || ENV['HEROKU_TEST_RUN_BRANCH'] || Hatchet.git_branch }
+    HATCHET_BUILDPACK_BRANCH = -> { ENV['HATCHET_BUILDPACK_BRANCH'] || Hatchet.git_branch }
 
     attr_reader :name, :stack, :repo_name, :app_config, :buildpacks, :reaper, :max_retries_count
 


### PR DESCRIPTION
Since Circle CI, GitHub Actions, and Heroku CI are widely used internally and across the ecosystem, I thought it might make sense to centralize this detection. Otherwise, we're looking at copying it around as discussed in https://github.com/heroku/heroku-buildpack-nodejs/pull/1033#pullrequestreview-1120488083 and https://github.com/heroku/hatchet/issues/179.