### PR TITLE
Scale to size 'basic' in App.teardown!

### DIFF
--- a/lib/hatchet/app.rb
+++ b/lib/hatchet/app.rb
@@ -360,7 +360,7 @@ module Hatchet
 
       if @run_multi_is_setup
         @run_multi_array.map(&:join)
-        platform_api.formation.update(name, "web", {"size" => "free"})
+        platform_api.formation.update(name, "web", {"size" => "basic"})
       end
 
     ensure


### PR DESCRIPTION
Scaling to size 'free' is no longer possible, so this is now causing test failures for users of run_multi

GUS-W-12421816