### PR TITLE
Change App#teardown! to delete apps immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## HEAD
 
+- Breaking change: Delete apps on teardown. Previously hatchet would delete apps lazily to help with debugging. This behavior allowed developers to inspect logs and `heroku run bash` in the event of an unexpected failure. In practice, it is rarely needed and causes accounts to retain apps indefinitely. Previously there was no cost to retaining applications, but now `basic` applications incur a charge. Change details:
+  - The application teardown process now deletes applications directly.
+  - To skip destroying applications on teardown, set `HEROKU_DEBUG_EXPENSIVE=1`. This env var will cause `App#teardown!` to skip deletion so you can introspect why one failed.
+  - When hatchet needs a new application, it will first delete all applications that are created at least `HATCHET_ALIVE_TTL_MINUTES` ago. If it cannot delete any applications and the account is already at `HATCHET_APP_LIMIT`, it will sleep and try again later.
+  - Introduce `--older-than` flag to `hatchet destroy` CLI command. For example, the command `hatchet destroy --older-than=7`will remove any apps older than the provided value (in minutes).
 - Add support for GitHub Actions env vars (https://github.com/heroku/hatchet/pull/189)
 
 ## 7.4.0

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -106,20 +106,27 @@ class HatchetCLI < Thor
     end
   end
 
-  desc "destroy [NAME]", "Deletes applications"
-  option :all, :type => :boolean
-  def destroy(name=nil)
+  desc "destroy", "Deletes application(s)"
+  option :all, type: :boolean, desc: "Delete ALL hatchet apps"
+  option :older_than, type: :numeric, desc: "Delete all hatchet apps older than N minutes"
+  def destroy
     api_key      = ENV['HEROKU_API_KEY'] || `heroku auth:token`.chomp
     platform_api = PlatformAPI.connect_oauth(api_key, cache: Moneta.new(:Null))
     api_rate_limit = ApiRateLimit.new(platform_api)
     reaper       = Hatchet::Reaper.new(api_rate_limit: api_rate_limit)
 
-    if options[:all]
+    case
+    when options[:all]
+      puts "Destroying ALL apps"
       reaper.destroy_all
-    elsif !name.nil?
-      reaper.destroy_by_name(name)
+      puts "Done"
+    when options[:older_than]
+      minutes = options[:older_than].to_i
+      puts "Destroying apps older than #{minutes}m"
+      reaper.destroy_older_apps(minutes: minutes)
+      puts "Done"
     else
-      raise "Must provide an app name or --all"
+      raise "No flags given run `hatchet help destroy` for options"
     end
   end
 

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -1,136 +1,96 @@
 require 'tmpdir'
 
 module Hatchet
-  # This class lazilly deletes hatchet apps
+  # Delete apps
   #
-  # When the reaper is called, it will check if the system has too many apps (Bassed off of HATCHET_APP_LIMIT), if so it will attempt
-  # to delete an app to free up capacity. The goal of lazilly deleting apps is to temporarilly keep
-  # apps around for debugging if they fail.
+  # Delete a single app:
   #
-  # When App#teardown! is called on an app it is marked as being in a "finished" state by turning
-  # on maintenance mode. The reaper will delete these in order (oldest first).
+  #   @reaper.destroy_with_log(id: id, name: name, reason: "console")
   #
-  # If no apps are marked as being "finished" then the reaper will check to see if the oldest app
-  # has been alive for a long enough period for it's tests to finish (configured by HATCHET_ALIVE_TTL_MINUTES env var).
-  # If the "unfinished" app has been alive that long it will be deleted. If not, the system will sleep for a period of time
-  # in an attempt to allow other apps to move to be "finished".
+  # Clear out all apps older than HATCHET_ALIVE_TTL_MINUTES:
   #
-  # This class only limits and the number of "hatchet" apps on the system. Prevously there was a maximum of 100 apps on a
-  # Heroku account. Now a user can belong to multiple orgs and the total number of apps they have access to is no longer
-  # fixed at 100. Instead of hard coding a maximum limit, this failure mode is handled by forcing deletion of
-  # an app when app creation fails. In the future we may find a better way of detecting this failure mode
+  #   @reaper.destroy_older_apps
+  #
+  # If you need to clear up space or wait for space to be cleared
+  # up then:
+  #
+  #   @reaper.clean_old_or_sleep
+  #
   #
   # Notes:
   #
   # - The class uses a file mutex so that multiple processes on the same machine do not attempt to run the
   #   reaper at the same time.
-  # - AlreadyDeletedError will be raised if an app has already been deleted (possibly by another test run on
-  #   another machine). When this happens, the system will automatically attempt to reap another app.
   class Reaper
     class AlreadyDeletedError < StandardError; end
 
     HATCHET_APP_LIMIT = Integer(ENV["HATCHET_APP_LIMIT"] || 20)  # the number of apps hatchet keeps around
     DEFAULT_REGEX = /^#{Regexp.escape(Hatchet::APP_PREFIX)}[a-f0-9]+/
+    TTL_MINUTES = ENV.fetch("HATCHET_ALIVE_TTL_MINUTES", "7").to_i
 
     attr_accessor :io, :hatchet_app_limit
 
     def initialize(api_rate_limit: , regex: DEFAULT_REGEX, io: STDOUT, hatchet_app_limit:  HATCHET_APP_LIMIT, initial_sleep: 10)
-      @api_rate_limit = api_rate_limit
-      @regex = regex
       @io = io
-      @finished_hatchet_apps = []
-      @unfinished_hatchet_apps = []
-      @app_count = 0
-      @hatchet_app_limit = hatchet_app_limit
+      @apps = []
+      @regex = regex
+      @limit = hatchet_app_limit
+      @api_rate_limit = api_rate_limit
       @reaper_throttle = ReaperThrottle.new(initial_sleep: initial_sleep)
     end
 
-    def cycle(app_exception_message: false)
+    # Called when we need an app, but are over limit or
+    # if an exception has occured that was possibly triggered
+    # by apps being over limit
+    def clean_old_or_sleep
       # Protect against parallel deletion of the same app on the same system
       mutex_file = File.open("#{Dir.tmpdir()}/hatchet_reaper_mutex", File::CREAT)
       mutex_file.flock(File::LOCK_EX)
 
-      refresh_app_list if @finished_hatchet_apps.empty?
+      destroy_older_apps(force_refresh: true)
 
-      # To be safe try to delete an app even if we're not over the limit
-      # since the exception may have been caused by going over the maximum account limit
-      if app_exception_message
+      if @apps.length > @limit
+        age = AppAge.new(created_at: @apps.last["created_at"], ttl_minutes: TTL_MINUTES)
+        @reaper_throttle.call(max_sleep: age.sleep_for_ttl) do |sleep_for|
           io.puts <<-EOM.strip_heredoc
-            WARNING: Running reaper due to exception on app
-                     #{stats_string}
-                     Exception: #{app_exception_message}
+            WARNING: Hatchet app limit reached (#{@apps.length}/#{@limit})
+                     All known apps are younger than #{TTL_MINUTES} minutes
           EOM
-        reap_once
-      end
 
-      while over_limit?
-        reap_once
+          sleep(sleep_for)
+        end
       end
     ensure
       mutex_file.close
     end
 
-    def stats_string
-      "total_app_count: #{@app_count}, hatchet_app_count: #{hatchet_app_count}/#{HATCHET_APP_LIMIT}, finished: #{@finished_hatchet_apps.length}, unfinished: #{@unfinished_hatchet_apps.length}"
-    end
+    # Destroys apps that are older than the given argument (expecting integer minutes)
+    def destroy_older_apps(minutes: TTL_MINUTES, force_refresh: @apps.empty?)
+      refresh_app_list if force_refresh
 
-    def over_limit?
-      hatchet_app_count > hatchet_app_limit
+      @apps.each do |app|
+        age = AppAge.new(created_at: app["created_at"], ttl_minutes: minutes)
+        if age.can_delete?
+          destroy_with_log(
+            name: app["name"],
+            id: app["id"],
+            reason: "app age (#{age.in_minutes}m) is older than #{minutes}m"
+          )
+        end
+      rescue AlreadyDeletedError
+        # Ignore, keep going
+      end
     end
 
     # No guardrails, will delete all apps that match the hatchet namespace
-    def destroy_all
-      refresh_app_list
+    def destroy_all(force_refresh: @apps.empty?)
+      refresh_app_list if force_refresh
 
-      (@finished_hatchet_apps + @unfinished_hatchet_apps).each do |app|
+      @apps.each do |app|
         begin
-          destroy_with_log(name: app["name"], id: app["id"])
+          destroy_with_log(name: app["name"], id: app["id"], reason: "destroy all")
         rescue AlreadyDeletedError
           # Ignore, keep going
-        end
-      end
-    end
-
-    private def reap_once
-      refresh_app_list if @finished_hatchet_apps.empty?
-
-      if (app = @finished_hatchet_apps.pop)
-        destroy_with_log(name: app["name"], id: app["id"])
-      elsif (app = @unfinished_hatchet_apps.pop)
-        destroy_if_old_enough(app)
-      end
-    rescue AlreadyDeletedError
-      retry
-    end
-
-    # Checks to see if the given app is older than the HATCHET_ALIVE_TTL_MINUTES
-    # if so, then the app is deleted, otherwise the reaper sleeps for a period of time after which
-    # It can try again to delete another app. The hope is that some apps will be marked as finished
-    # in that time
-    private def destroy_if_old_enough(app)
-      age = AppAge.new(
-        created_at: app["created_at"],
-        ttl_minutes: ENV.fetch("HATCHET_ALIVE_TTL_MINUTES", "7").to_i
-      )
-      if age.can_delete?
-        io.puts "WARNING: Destroying an app without maintenance mode on, app: #{app["name"]}, app_age: #{age.in_minutes} minutes"
-
-        destroy_with_log(name: app["name"], id: app["id"])
-      else
-        # We're not going to delete it yet, so put it back
-        @unfinished_hatchet_apps << app
-
-        # Sleep, try again later
-        @reaper_throttle.call(max_sleep: age.sleep_for_ttl) do |sleep_for|
-          io.puts <<-EOM.strip_heredoc
-            WARNING: Attempting to destroy an app without maintenance mode on, but it is not old enough. app: #{app["name"]}, app_age: #{age.in_minutes} minutes
-                     This can happen if App#teardown! is not called on an application, which will leave it in an 'unfinished' state
-                     This can also happen if you're trying to run more tests concurrently than your currently set value for HATCHET_APP_COUNT
-                     Sleeping: #{sleep_for} seconds before trying to find another app to reap"
-                     #{stats_string}, HATCHET_ALIVE_TTL_MINUTES=#{age.ttl_minutes}
-          EOM
-
-          sleep(sleep_for)
         end
       end
     end
@@ -140,28 +100,15 @@ module Hatchet
     end
 
     private def refresh_app_list
-      apps = get_heroku_apps.
+      @apps = get_heroku_apps.
+        filter {|app| app["name"].match(@regex) }.
         map {|app| app["created_at"] = DateTime.parse(app["created_at"].to_s); app }.
         sort_by { |app| app["created_at"] }.
         reverse # Ascending order, oldest is last
-
-      @app_count = apps.length
-
-      @finished_hatchet_apps.clear
-      @unfinished_hatchet_apps.clear
-      apps.each do |app|
-        next unless app["name"].match(@regex)
-
-        if app["maintenance"]
-          @finished_hatchet_apps << app
-        else
-          @unfinished_hatchet_apps << app
-        end
-      end
     end
 
-    private def destroy_with_log(name:, id:)
-      message = "Destroying #{name.inspect}: #{id}, #{stats_string}"
+    def destroy_with_log(name:, id:, reason: )
+      message = "Destroying #{name.inspect}: #{id}, (#{@apps.length}/#{@limit}) reason: #{reason}"
 
       @api_rate_limit.call.app.delete(id)
 
@@ -179,10 +126,6 @@ module Hatchet
       request_id = e.response.headers["Request-Id"]
       io.puts "Duplicate destroy attempted #{name.inspect}: #{id}, status: 403, request_id: #{request_id}"
       raise AlreadyDeletedError.new
-    end
-
-    private def hatchet_app_count
-      @finished_hatchet_apps.length + @unfinished_hatchet_apps.length
     end
   end
 end

--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -15,15 +15,7 @@ describe "CIFourTest" do
       expect(test_run.output).to match(string)
       expect(test_run.output).to match("Using rake")
       expect(test_run.output).to_not match("Installing rake")
-
-      expect(app.platform_api.app.info(app.name)["maintenance"]).to be_falsey
     end
-
-    # After the app is updated, there's no guarantee it will still exist
-    # so we cannot rely on an api call to determine maintenance mode
-    app_update_info = app.instance_variable_get(:"@app_update_info")
-    expect(app_update_info["name"]).to eq(app.name)
-    expect(app_update_info["maintenance"]).to be_truthy
   end
 
   it "error with bad app" do


### PR DESCRIPTION
- Breaking change: Delete apps on teardown. Previously hatchet would delete apps lazilly to help with debugging. This allowed developers to inspect logs and `heroku run bash` in the event of an unexpected failure. In practice it's rarely needed and means accounts retain a lot of Heroku apps. Previously there was no cost to retaining applications, but now `basic` applications incur a charge. Change details:
  - The application teardown process now deletes applications directly.
  - To skip destroying applications on teardown set `HEROKU_DEBUG_EXPENSIVE=1`. This will keep your applications around so that you can introspect why one failed.
  - When Hatchet needs a new application it will first delete all applications that are created at least `HATCHET_ALIVE_TTL_MINUTES` ago. If it cannot delete any applications and the account is already at `HATCHET_APP_LIMIT` it will sleep and try again later.
  - The hatchet cli has a new flag for destroy `hatchet destroy --older-than=7`. This will remove any apps older than the provided value (in minutes)

GUS-W-12027262