### PR TITLE
Fix bug #196 && prepare v8.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## 8.0.0
+
 - Breaking change: Delete apps on teardown. Previously hatchet would delete apps lazily to help with debugging. This behavior allowed developers to inspect logs and `heroku run bash` in the event of an unexpected failure. In practice, it is rarely needed and causes accounts to retain apps indefinitely. Previously there was no cost to retaining applications, but now `basic` applications incur a charge. Change details:
   - The application teardown process now deletes applications directly.
   - To skip destroying applications on teardown, set `HEROKU_DEBUG_EXPENSIVE=1`. This env var will cause `App#teardown!` to skip deletion so you can introspect why one failed.

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "7.4.0"
+  VERSION = "8.0.0"
 end

--- a/spec/unit/default_ci_branch_spec.rb
+++ b/spec/unit/default_ci_branch_spec.rb
@@ -1,0 +1,27 @@
+
+require "spec_helper"
+
+describe "DefaultCIBranch" do
+  it "doesn't error on empty env" do
+    out = DefaultCIBranch.new(env: {}).call
+    expect(out).to be_nil
+  end
+
+  it "GitHub PRs" do
+    out = DefaultCIBranch.new(env: {"GITHUB_HEAD_REF" => "iAmaPR"}).call
+    expect(out).to eq("iAmaPR")
+
+    out = DefaultCIBranch.new(env: {"GITHUB_HEAD_REF" => ""}).call
+    expect(out).to be_nil
+  end
+
+  it "GitHub branches" do
+    out = DefaultCIBranch.new(env: {"GITHUB_REF_NAME" => "iAmaBranch"}).call
+    expect(out).to eq("iAmaBranch")
+  end
+
+  it "heroku" do
+    out = DefaultCIBranch.new(env: {"HEROKU_TEST_RUN_BRANCH" => "iAmaBranch"}).call
+    expect(out).to eq("iAmaBranch")
+  end
+end


### PR DESCRIPTION
The call to `empty?` will fail if the key GITHUB_HEAD_REF does not exist.

Before fixing this problem, I extracted the logic to its own testable class. Then I added tests, which also showed that `GITHUB_REF_NAME` would never be returned either (a previously unknown bug) because `!@env["GITHUB_HEAD_REF"]&.empty?` will always be truthy unless the key exists and it's empty.

This would (possibly) be cleaner with pattern matching. Ruby has pattern matching but we can't use it yet due to minimum supported Ruby version https://docs.ruby-lang.org/en/3.0/syntax/pattern_matching_rdoc.html.

Close #196