### PR TITLE
Fix multiple duplicate deletion attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 8.0.1
+
+- Bugfix: Lock and sleep and refresh API when duplicate app deletion detected (https://github.com/heroku/hatchet/pull/198)
+
 ## 8.0.0
 
 - Breaking change: Delete apps on teardown. Previously hatchet would delete apps lazily to help with debugging. This behavior allowed developers to inspect logs and `heroku run bash` in the event of an unexpected failure. In practice, it is rarely needed and causes accounts to retain apps indefinitely. Previously there was no cost to retaining applications, but now `basic` applications incur a charge. Change details:

--- a/bin/hatchet
+++ b/bin/hatchet
@@ -123,7 +123,11 @@ class HatchetCLI < Thor
     when options[:older_than]
       minutes = options[:older_than].to_i
       puts "Destroying apps older than #{minutes}m"
-      reaper.destroy_older_apps(minutes: minutes)
+      reaper.destroy_older_apps(
+        minutes: minutes,
+        force_refresh: true,
+        on_conflict: :refresh_api_and_continue
+      )
       puts "Done"
     else
       raise "No flags given run `hatchet help destroy` for options"

--- a/lib/hatchet/reaper.rb
+++ b/lib/hatchet/reaper.rb
@@ -28,6 +28,13 @@ module Hatchet
     DEFAULT_REGEX = /^#{Regexp.escape(Hatchet::APP_PREFIX)}[a-f0-9]+/
     TTL_MINUTES = ENV.fetch("HATCHET_ALIVE_TTL_MINUTES", "7").to_i
 
+    # Protect against parallel deletion on the same machine
+    # via concurrent processes
+    #
+    # Does not protect against distributed systems on different
+    # machines trying to delete the same applications
+    MUTEX_FILE = File.open(File.join(Dir.tmpdir(), "hatchet_reaper_mutex"), File::CREAT)
+
     attr_accessor :io, :hatchet_app_limit
 
     def initialize(api_rate_limit: , regex: DEFAULT_REGEX, io: STDOUT, hatchet_app_limit:  HATCHET_APP_LIMIT, initial_sleep: 10)
@@ -43,47 +50,73 @@ module Hatchet
     # if an exception has occured that was possibly triggered
     # by apps being over limit
     def clean_old_or_sleep
-      # Protect against parallel deletion of the same app on the same system
-      mutex_file = File.open("#{Dir.tmpdir()}/hatchet_reaper_mutex", File::CREAT)
-      mutex_file.flock(File::LOCK_EX)
-
+      # Locking happens inside the function
       destroy_older_apps(force_refresh: true)
 
+      # If we didn't clean enough, then sleep a bit and return control
+      # to the user, they can decide what to do next.
       if @apps.length > @limit
         age = AppAge.new(created_at: @apps.last["created_at"], ttl_minutes: TTL_MINUTES)
         @reaper_throttle.call(max_sleep: age.sleep_for_ttl) do |sleep_for|
           io.puts <<-EOM.strip_heredoc
             WARNING: Hatchet app limit reached (#{@apps.length}/#{@limit})
-                     All known apps are younger than #{TTL_MINUTES} minutes
+                     All known apps are younger than #{TTL_MINUTES} minutes.
+
+                     sleeping (#{sleep_for}s)
           EOM
 
           sleep(sleep_for)
         end
       end
-    ensure
-      mutex_file.close
     end
 
     # Destroys apps that are older than the given argument (expecting integer minutes)
+    #
+    # This method might be running concurrently on multiple processes or multiple
+    # machines.
     def destroy_older_apps(minutes: TTL_MINUTES, force_refresh: @apps.empty?)
+      MUTEX_FILE.flock(File::LOCK_EX)
+
       refresh_app_list if force_refresh
 
-      @apps.each do |app|
+      while app = @apps.pop
         age = AppAge.new(created_at: app["created_at"], ttl_minutes: minutes)
         if age.can_delete?
           destroy_with_log(
-            name: app["name"],
             id: app["id"],
+            name: app["name"],
             reason: "app age (#{age.in_minutes}m) is older than #{minutes}m"
           )
+        else
+          @apps.push(app)
+          break
         end
-      rescue AlreadyDeletedError
-        # Ignore, keep going
       end
+    rescue AlreadyDeletedError => e
+      # Indicates either outdated information or a race condition
+      #
+      # Sleep to see if another process will clean up everything for
+      # us and then re-populate apps from the API
+      @reaper_throttle.call(max_sleep: TTL_MINUTES) do |sleep_for|
+        io.puts <<-EOM.strip_heredoc
+          WARNING: Possible race condition detected
+                   sleeping (#{sleep_for}s) and refreshing app list from API.
+
+                   #{e}
+        EOM
+
+        sleep(sleep_for)
+
+        refresh_app_list
+      end
+    ensure
+      MUTEX_FILE.flock(File::LOCK_UN)
     end
 
     # No guardrails, will delete all apps that match the hatchet namespace
     def destroy_all(force_refresh: @apps.empty?)
+      MUTEX_FILE.flock(File::LOCK_EX)
+
       refresh_app_list if force_refresh
 
       @apps.each do |app|
@@ -93,6 +126,8 @@ module Hatchet
           # Ignore, keep going
         end
       end
+    ensure
+      MUTEX_FILE.flock(File::LOCK_UN)
     end
 
     private def get_heroku_apps
@@ -117,15 +152,15 @@ module Hatchet
       body = e.response.body
       request_id = e.response.headers["Request-Id"]
       if body =~ /Couldn\'t find that app./
-        io.puts "Duplicate destroy attempted #{name.inspect}: #{id}, status: 404, request_id: #{request_id}"
-        raise AlreadyDeletedError.new
+        message = "Duplicate destroy attempted #{name.inspect}: #{id}, status: 404, request_id: #{request_id}"
+        raise AlreadyDeletedError.new(message)
       else
         raise e
       end
     rescue Excon::Error::Forbidden => e
       request_id = e.response.headers["Request-Id"]
-      io.puts "Duplicate destroy attempted #{name.inspect}: #{id}, status: 403, request_id: #{request_id}"
-      raise AlreadyDeletedError.new
+      message = "Duplicate destroy attempted #{name.inspect}: #{id}, status: 403, request_id: #{request_id}"
+      raise AlreadyDeletedError.new(message)
     end
   end
 end

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "8.0.0"
+  VERSION = "8.0.1"
 end

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -43,7 +43,7 @@ describe "AppTest" do
 
     reaper = app.reaper
 
-    def reaper.clean_old_or_sleep; @app_exception_message = true; end
+    def reaper.destroy_older_apps(*args, **kwargs, &block); @app_exception_message = true; end
     def reaper.clean_old_was_called?; @app_exception_message; end
 
     expect {


### PR DESCRIPTION
When multiple processes are attempting to cull the old apps list to free up enough space (to get under the limit), each will try to delete the same app.

We already introduced a file based lock for multiple processes on the same machine. However the lock was not being used while clearing out old apps. That has been added.

This file locking doesn't fix the problem, but it limits it instead of N machines running M processes, you only have to account for N machines. 

The next fix is that when a duplicate deletion is detected, instead of having all machines continue on as fast as possible, the machines that "lost" the race will sleep to allow the winner to continue removing apps. When it wakes up it will refresh its API list and try again. This will happen in a loop until there are no more apps over TTL or it becomes the winner and other apps must sleep. This sleep logic uses the shared reaper backoff algorithm shared with the Platform gem detailed in my blog https://www.schneems.com/2020/07/08/a-fast-car-needs-good-brakes-how-we-added-client-rate-throttling-to-the-platform-api-gem/. When it begins to sleep, it will be a very small number, if there are lots of apps to be deleted and this triggers over and over, it will sleep longer and longer until it asymptotically reaches the max sleep value which is also the max TTL value. 

The last change is that the @apps list (essentially a cache from the API) was not modified in this `destroy_older_apps` method so unless `refresh_app_list` was called every run to this method starts at the end and would trigger N `AlreadyDeleted` errors as it's in a data race with itself. This new code now removes an app from the list as they're being deleted to avoid this problem.