### PR TITLE
Add a scheduled Hatchet app cleaner workflow

### DIFF
--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -1,0 +1,31 @@
+name: Hatchet app cleaner
+
+on:
+  schedule:
+    # Daily at 6am UTC.
+    - cron: "0 6 * * *"
+  # Allow the workflow to be manually triggered too.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hatchet-app-cleaner:
+    runs-on: ubuntu-latest
+    env:
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      HEROKU_API_USER: ${{ secrets.HEROKU_API_USER }}
+      HEROKU_DISABLE_AUTOUPDATE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Ruby and dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.1"
+      - name: Run Hatchet destroy
+        # Only apps older than 10 minutes are destroyed, to ensure that any
+        # in progress CI runs are not interrupted.
+        run: bundle exec hatchet destroy --older-than 10


### PR DESCRIPTION
As of Hatchet v8.x, Hatchet now:
- Removes the apps it creates after each test runs, rather than only enabling maintenance mode. This occurs even if an individual test fails.
- Cleans up older apps iff it runs into the app limit. (This is only done when the app limit is hit, in order to prevent hundreds of unnecessary API requests, when test concurrency is high.)

However, leftover apps can still occur in the following cases:
- The GitHub Actions run is cancelled, or aborts in a non-clean way.
- If a Hatchet bug (or a mis-use of Hatchet by the tests) cause Hatchet to exit non-cleanly.
- If there is a platform incident causing the Heroku API to not be available.

Therefore, this scheduled cleanup job has been added to catch any such leftover apps. It runs daily at 6am UTC, and can also be triggered manually via the GitHub dashboard.

The cleanup job only deletes apps older than 10 minutes, so that it doesn't break any in progress CI jobs.

GUS-W-12629391.