### PR TITLE
Only call teardown once per outer block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD
 
+## 8.0.2
+
+- Bugfix: Allow nested deploy blocks with new teardown logic (https://github.com/heroku/hatchet/pull/201)
+
 ## 8.0.1
 
 - Bugfix: Lock and sleep and refresh API when duplicate app deletion detected (https://github.com/heroku/hatchet/pull/198)

--- a/lib/hatchet/version.rb
+++ b/lib/hatchet/version.rb
@@ -1,3 +1,3 @@
 module Hatchet
-  VERSION = "8.0.1"
+  VERSION = "8.0.2"
 end

--- a/spec/hatchet/app_spec.rb
+++ b/spec/hatchet/app_spec.rb
@@ -1,20 +1,6 @@
 require("spec_helper")
 
 describe "AppTest" do
-  it "annotates rspec expectation failures" do
-    app = Hatchet::Runner.new("default_ruby")
-    error = nil
-    begin
-      app.annotate_failures do
-        expect(true).to eq(false)
-      end
-    rescue RSpec::Expectations::ExpectationNotMetError => e
-      error = e
-    end
-
-    expect(error.message).to include(app.name)
-  end
-
   it "does not modify local files by mistake" do
     Dir.mktmpdir do |dir_1|
       app = Hatchet::Runner.new(dir_1)
@@ -29,7 +15,6 @@ describe "AppTest" do
         entries_array -= ["..", ".", "foo.txt"]
         expect(entries_array).to be_empty
 
-
         entries_array = Dir.entries(dir_1)
         entries_array -= ["..", ".", "foo.txt"]
         expect(entries_array).to be_empty
@@ -37,33 +22,8 @@ describe "AppTest" do
     end
   end
 
-  it "calls reaper if cannot create an app" do
-    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
-    def app.heroku_api_create_app(*args); raise StandardError.new("made you look"); end
-
-    reaper = app.reaper
-
-    def reaper.destroy_older_apps(*args, **kwargs, &block); @app_exception_message = true; end
-    def reaper.clean_old_was_called?; @app_exception_message; end
-
-    expect {
-      app.create_app
-    }.to raise_error("made you look")
-
-    expect(reaper.clean_old_was_called?).to be_truthy
-  end
-
-  it "app with default" do
-    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
-    expect(app.buildpacks.first).to match("https://github.com/heroku/heroku-buildpack-ruby")
-  end
-
-  it "default_buildpack is only computed once" do
-    expect(Hatchet::App.default_buildpack.object_id).to eq(Hatchet::App.default_buildpack.object_id)
-  end
-
   it "create app with stack" do
-    stack = "heroku-18"
+    stack = "heroku-20"
     app = Hatchet::App.new("default_ruby", stack: stack)
     app.create_app
     expect(app.platform_api.app.info(app.name)["build_stack"]["name"]).to eq(stack)

--- a/spec/unit/app_spec.rb
+++ b/spec/unit/app_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+# Tests in this file do not deploy to Heroku
+describe "App unit tests" do
+  it "annotates rspec expectation failures" do
+    app = Hatchet::Runner.new("default_ruby")
+    error = nil
+    begin
+      app.annotate_failures do
+        expect(true).to eq(false)
+      end
+    rescue RSpec::Expectations::ExpectationNotMetError => e
+      error = e
+    end
+
+    expect(error.message).to include(app.name)
+  end
+
+  it "calls reaper if cannot create an app" do
+    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
+    def app.heroku_api_create_app(*args); raise StandardError.new("made you look"); end
+
+    reaper = app.reaper
+
+    def reaper.destroy_older_apps(*args, **kwargs, &block); @app_exception_message = true; end
+    def reaper.clean_old_was_called?; @app_exception_message; end
+
+    expect {
+      app.create_app
+    }.to raise_error("made you look")
+
+    expect(reaper.clean_old_was_called?).to be_truthy
+  end
+
+  it "app with default" do
+    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
+    expect(app.buildpacks.first).to match("https://github.com/heroku/heroku-buildpack-ruby")
+  end
+
+  it "default_buildpack is only computed once" do
+    expect(Hatchet::App.default_buildpack.object_id).to eq(Hatchet::App.default_buildpack.object_id)
+  end
+
+  it "nested deploy block only calls teardown once" do
+    @deploy = 0
+    app = Hatchet::App.new("default_ruby", buildpacks: [:default])
+    def app.in_dir_setup!; ;end # Don't create an app
+    def app.push_with_retry!; end # Don't try pushing to it
+    def app.teardown!; @teardown ||=0; @teardown += 1 end
+    def app.get_teardown_count; @teardown; end
+
+    app.deploy do |app|
+      @deploy += 1
+      app.deploy do |app|
+        @deploy += 1
+      end
+      app.deploy do |app|
+        @deploy += 1
+      end
+    end
+
+    expect(app.get_teardown_count).to eq(1)
+    expect(@deploy).to eq(3)
+  end
+end


### PR DESCRIPTION
The deploy method can be called within the a deploy block. When this happens, `teardown!` triggers an immediate app deletion which will cause other code within that block to be deleted.

If I could re-write all of this, I would use a different abstraction instead of having App be the god-object. Since I'm living with this existing domain model, we can record the outermost block ID and only fire teardown when that block is exiting. This method ensures that teardown is only ever called once.