### PR TITLE
Add support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-22.04
     env:
       HATCHET_APP_LIMIT: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Add support for Ruby 3.2 (https://github.com/heroku/hatchet/pull/203)
+
 ## 8.0.2
 
 - Bugfix: Allow nested deploy blocks with new teardown logic (https://github.com/heroku/hatchet/pull/201)

--- a/etc/ci_setup.rb
+++ b/etc/ci_setup.rb
@@ -12,7 +12,7 @@ end
 puts "== Setting Up CI =="
 
 netrc_file = "#{ENV['HOME']}/.netrc"
-unless File.exists?(netrc_file)
+unless File.exist?(netrc_file)
   File.open(netrc_file, 'w') do |file|
     file.write <<-EOF
 machine git.heroku.com


### PR DESCRIPTION
Currently `hatchet ci:setup` fails on Ruby 3.2, with:

```
bundle exec hatchet ci:setup
/home/runner/work/heroku-buildpack-python/heroku-buildpack-python/vendor/bundle/ruby/3.2.0/gems/heroku_hatchet-8.0.2/etc/ci_setup.rb:15:in `<main>': undefined method `exists?' for File:Class (NoMethodError)

unless File.exists?(netrc_file)
           ^^^^^^^^
Did you mean?  exist?
```