### PR TITLE
Test against Ruby 3.3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-22.04
     env:
       HATCHET_APP_LIMIT: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## HEAD
 
-- Add support for Ruby 3.2 (https://github.com/heroku/hatchet/pull/203)
+- Add support for Ruby 3.2 and 3.3 (https://github.com/heroku/hatchet/pull/203 and https://github.com/heroku/hatchet/pull/208)
 
 ## 8.0.2
 


### PR DESCRIPTION
Since Ruby 3.3 is the default Ruby version when using the `ruby` / `ruby@3` Homebrew package aliases, so has a high chance of being what people are now using locally.

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/