### PR TITLE
Fix failing tests

### DIFF
--- a/spec/hatchet/ci_spec.rb
+++ b/spec/hatchet/ci_spec.rb
@@ -13,7 +13,6 @@ describe "CI" do
       test_run.run_again
 
       expect(test_run.output).to match(string)
-      expect(test_run.output).to match("Using rake")
       expect(test_run.output).to_not match("Installing rake")
     end
   end


### PR DESCRIPTION
Tests are failing with this output:

```

       expected "-----> Building on the Heroku-24 stack\n-----> Fetching https://github.com/heroku/heroku-buildpack-r...: rake test\n505b817aba132559e51bfc599fe8a1c7\n-----> Ruby buildpack tests completed successfully\n" to match "Using rake"
       Diff:
       @@ -1 +1,89 @@
       -Using rake
       +-----> Building on the Heroku-24 stack
       +-----> Fetching https://github.com/heroku/heroku-buildpack-ruby.git#main buildpack...
       +       buildpack downloaded
       +-----> Ruby app detected
       +-----> Installing bundler 2.3.25
       +-----> Removing BUNDLED WITH version in the Gemfile.lock
       +-----> Setting up Test for Ruby/Rack
...
       +-----> Installing dependencies using bundler 2.3.25
       +       Running: BUNDLE_WITHOUT='development' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       +       Bundle complete! 2 Gemfile dependencies, 3 gems now installed.
       +       Gems in the group 'development' were not installed.
       +       Bundled gems are installed into `./vendor/bundle`
       +       Bundle completed (0.45s)
       +       Cleaning up the bundler cache.
```

Bundler changed their output. They no longer emit gems that are already installed. I changed the default bundler version used when none is specified from bundler 1.x to 2.3.x so that's why this is failing now.

We are asserting that "Installing rake" is seen in the first build and not in the second build already. The goal was to show that caching is working. This line is not needed.